### PR TITLE
IsSymmetric

### DIFF
--- a/src/Numerics/LinearAlgebra/Generic/Matrix.cs
+++ b/src/Numerics/LinearAlgebra/Generic/Matrix.cs
@@ -1782,13 +1782,8 @@ namespace MathNet.Numerics.LinearAlgebra.Generic
 
                 for (var row = 0; row < RowCount; row++)
                 {
-                    for (var column = 0; column < ColumnCount; column++)
+                    for (var column = row + 1; column < ColumnCount; column++)
                     {
-                        if (column >= row)
-                        {
-                            continue;
-                        }
-
                         if (!At(row, column).Equals(At(column, row)))
                         {
                             return false;


### PR DESCRIPTION
Small bugfix and optimization. 

Unless there is a reason the loop needs to run from 0 to ColumnCount and explicitly skip values inside. 
