### PR TITLE
LeftMultiply with vector is exactly the same as TransposeThisAndMultiply with vector

### DIFF
--- a/src/Numerics/LinearAlgebra/Complex/DenseMatrix.cs
+++ b/src/Numerics/LinearAlgebra/Complex/DenseMatrix.cs
@@ -380,37 +380,6 @@ namespace MathNet.Numerics.LinearAlgebra.Complex
         }
 
         /// <summary>
-        /// Left multiply a matrix with a vector ( = vector * matrix ) and place the result in the result vector.
-        /// </summary>
-        /// <param name="leftSide">The vector to multiply with.</param>
-        /// <param name="result">The result of the multiplication.</param>
-        protected override void DoLeftMultiply(Vector<Complex> leftSide, Vector<Complex> result)
-        {
-            var denseLeft = leftSide as DenseVector;
-            var denseResult = result as DenseVector;
-
-            if (denseLeft == null || denseResult == null)
-            {
-                base.DoLeftMultiply(leftSide, result);
-            }
-            else
-            {
-                Control.LinearAlgebraProvider.MatrixMultiplyWithUpdate(
-                    Algorithms.LinearAlgebra.Transpose.DontTranspose,
-                    Algorithms.LinearAlgebra.Transpose.DontTranspose,
-                    1.0,
-                    denseLeft.Data,
-                    1,
-                    denseLeft.Count,
-                    Data,
-                    RowCount,
-                    ColumnCount,
-                    0.0,
-                    denseResult.Data);
-            }
-        }
-   
-        /// <summary>
         /// Multiplies this matrix with another matrix and places the results into the result matrix.
         /// </summary>
         /// <param name="other">The matrix to multiply with.</param>

--- a/src/Numerics/LinearAlgebra/Complex/Matrix.cs
+++ b/src/Numerics/LinearAlgebra/Complex/Matrix.cs
@@ -208,25 +208,6 @@ namespace MathNet.Numerics.LinearAlgebra.Complex
          }
 
         /// <summary>
-        /// Left multiply a matrix with a vector ( = vector * matrix ) and place the result in the result vector.
-        /// </summary>
-        /// <param name="leftSide">The vector to multiply with.</param>
-        /// <param name="result">The result of the multiplication.</param>
-        protected override void DoLeftMultiply(Vector<Complex> leftSide, Vector<Complex> result)
-        {
-            for (var j = 0; j < ColumnCount; j++)
-            {
-                var s = Complex.Zero;
-                for (var i = 0; i != leftSide.Count; i++)
-                {
-                    s += leftSide[i] * At(i, j);
-                }
-
-                result[j] = s;
-            }
-        }
-
-        /// <summary>
         /// Multiplies this matrix with another matrix and places the results into the result matrix.
         /// </summary>
         /// <param name="other">The matrix to multiply with.</param>

--- a/src/Numerics/LinearAlgebra/Complex32/DenseMatrix.cs
+++ b/src/Numerics/LinearAlgebra/Complex32/DenseMatrix.cs
@@ -380,37 +380,6 @@ namespace MathNet.Numerics.LinearAlgebra.Complex32
         }
 
         /// <summary>
-        /// Left multiply a matrix with a vector ( = vector * matrix ) and place the result in the result vector.
-        /// </summary>
-        /// <param name="leftSide">The vector to multiply with.</param>
-        /// <param name="result">The result of the multiplication.</param>
-        protected override void DoLeftMultiply(Vector<Complex32> leftSide, Vector<Complex32> result)
-        {
-            var denseLeft = leftSide as DenseVector;
-            var denseResult = result as DenseVector;
-
-            if (denseLeft == null || denseResult == null)
-            {
-                base.DoLeftMultiply(leftSide, result);
-            }
-            else
-            {
-                Control.LinearAlgebraProvider.MatrixMultiplyWithUpdate(
-                    Algorithms.LinearAlgebra.Transpose.DontTranspose,
-                    Algorithms.LinearAlgebra.Transpose.DontTranspose,
-                    1.0f,
-                    denseLeft.Data,
-                    1,
-                    denseLeft.Count,
-                    Data,
-                    RowCount,
-                    ColumnCount,
-                    0.0f,
-                    denseResult.Data);
-            }
-        }
-
-        /// <summary>
         /// Multiplies this matrix with another matrix and places the results into the result matrix.
         /// </summary>
         /// <param name="other">The matrix to multiply with.</param>

--- a/src/Numerics/LinearAlgebra/Complex32/Matrix.cs
+++ b/src/Numerics/LinearAlgebra/Complex32/Matrix.cs
@@ -218,25 +218,6 @@ namespace MathNet.Numerics.LinearAlgebra.Complex32
         }
 
         /// <summary>
-        /// Left multiply a matrix with a vector ( = vector * matrix ) and place the result in the result vector.
-        /// </summary>
-        /// <param name="leftSide">The vector to multiply with.</param>
-        /// <param name="result">The result of the multiplication.</param>
-        protected override void DoLeftMultiply(Vector<Complex32> leftSide, Vector<Complex32> result)
-        {
-            for (var j = 0; j < ColumnCount; j++)
-            {
-                var s = Complex32.Zero;
-                for (var i = 0; i != leftSide.Count; i++)
-                {
-                    s += leftSide[i] * At(i, j);
-                }
-
-                result[j] = s;
-            }
-        }
-
-        /// <summary>
         /// Multiplies this matrix with another matrix and places the results into the result matrix.
         /// </summary>
         /// <param name="other">The matrix to multiply with.</param>

--- a/src/Numerics/LinearAlgebra/Double/DenseMatrix.cs
+++ b/src/Numerics/LinearAlgebra/Double/DenseMatrix.cs
@@ -421,37 +421,6 @@ namespace MathNet.Numerics.LinearAlgebra.Double
         }
 
         /// <summary>
-        /// Left multiply a matrix with a vector ( = vector * matrix ) and place the result in the result vector.
-        /// </summary>
-        /// <param name="leftSide">The vector to multiply with.</param>
-        /// <param name="result">The result of the multiplication.</param>
-        protected override void DoLeftMultiply(Vector<double> leftSide, Vector<double> result)
-        {
-            var denseLeft = leftSide as DenseVector;
-            var denseResult = result as DenseVector;
-
-            if (denseLeft == null || denseResult == null)
-            {
-                base.DoLeftMultiply(leftSide, result);
-            }
-            else
-            {
-                Control.LinearAlgebraProvider.MatrixMultiplyWithUpdate(
-                    Algorithms.LinearAlgebra.Transpose.DontTranspose,
-                    Algorithms.LinearAlgebra.Transpose.DontTranspose,
-                    1.0,
-                    denseLeft.Data,
-                    1,
-                    denseLeft.Count,
-                    Data,
-                    RowCount,
-                    ColumnCount,
-                    0.0,
-                    denseResult.Data);
-            }
-        }
-
-        /// <summary>
         /// Multiplies this matrix with another matrix and places the results into the result matrix.
         /// </summary>
         /// <param name="other">The matrix to multiply with.</param>

--- a/src/Numerics/LinearAlgebra/Double/Matrix.cs
+++ b/src/Numerics/LinearAlgebra/Double/Matrix.cs
@@ -208,25 +208,6 @@ namespace MathNet.Numerics.LinearAlgebra.Double
         }
 
         /// <summary>
-        /// Left multiply a matrix with a vector ( = vector * matrix ) and place the result in the result vector.
-        /// </summary>
-        /// <param name="leftSide">The vector to multiply with.</param>
-        /// <param name="result">The result of the multiplication.</param>
-        protected override void DoLeftMultiply(Vector<double> leftSide, Vector<double> result)
-        {
-            for (var j = 0; j < ColumnCount; j++)
-            {
-                var s = 0.0;
-                for (var i = 0; i != leftSide.Count; i++)
-                {
-                    s += leftSide[i] * At(i, j);
-                }
-
-                result[j] = s;
-            }
-        }
-
-        /// <summary>
         /// Multiplies this matrix with another matrix and places the results into the result matrix.
         /// </summary>
         /// <param name="other">The matrix to multiply with.</param>

--- a/src/Numerics/LinearAlgebra/Generic/Matrix.Arithmetic.cs
+++ b/src/Numerics/LinearAlgebra/Generic/Matrix.Arithmetic.cs
@@ -420,7 +420,10 @@ namespace MathNet.Numerics.LinearAlgebra.Generic
         /// </summary>
         /// <param name="leftSide">The vector to multiply with.</param>
         /// <param name="result">The result of the multiplication.</param>
-        protected abstract void DoLeftMultiply(Vector<T> leftSide, Vector<T> result);
+        protected void DoLeftMultiply(Vector<T> leftSide, Vector<T> result)
+        {
+            DoTransposeThisAndMultiply(leftSide, result);
+        }
 
         /// <summary>
         /// Multiplies this matrix with another matrix and places the results into the result matrix.

--- a/src/Numerics/LinearAlgebra/Single/DenseMatrix.cs
+++ b/src/Numerics/LinearAlgebra/Single/DenseMatrix.cs
@@ -420,37 +420,6 @@ namespace MathNet.Numerics.LinearAlgebra.Single
         }
 
         /// <summary>
-        /// Left multiply a matrix with a vector ( = vector * matrix ) and place the result in the result vector.
-        /// </summary>
-        /// <param name="leftSide">The vector to multiply with.</param>
-        /// <param name="result">The result of the multiplication.</param>
-        protected override void DoLeftMultiply(Vector<float> leftSide, Vector<float> result)
-        {
-            var denseLeft = leftSide as DenseVector;
-            var denseResult = result as DenseVector;
-
-            if (denseLeft == null || denseResult == null)
-            {
-                base.DoLeftMultiply(leftSide, result);
-            }
-            else
-            {
-                Control.LinearAlgebraProvider.MatrixMultiplyWithUpdate(
-                    Algorithms.LinearAlgebra.Transpose.DontTranspose,
-                    Algorithms.LinearAlgebra.Transpose.DontTranspose,
-                    1.0f,
-                    denseLeft.Data,
-                    1,
-                    denseLeft.Count,
-                    Data,
-                    RowCount,
-                    ColumnCount,
-                    0.0f,
-                    denseResult.Data);
-            }
-        }
-
-        /// <summary>
         /// Multiplies this matrix with another matrix and places the results into the result matrix.
         /// </summary>
         /// <param name="other">The matrix to multiply with.</param>

--- a/src/Numerics/LinearAlgebra/Single/Matrix.cs
+++ b/src/Numerics/LinearAlgebra/Single/Matrix.cs
@@ -198,25 +198,6 @@ namespace MathNet.Numerics.LinearAlgebra.Single
          }
 
         /// <summary>
-        /// Left multiply a matrix with a vector ( = vector * matrix ) and place the result in the result vector.
-        /// </summary>
-        /// <param name="leftSide">The vector to multiply with.</param>
-        /// <param name="result">The result of the multiplication.</param>
-        protected override void DoLeftMultiply(Vector<float> leftSide, Vector<float> result)
-        {
-            for (var j = 0; j < ColumnCount; j++)
-            {
-                var s = 0.0f;
-                for (var i = 0; i != leftSide.Count; i++)
-                {
-                    s += leftSide[i] * At(i, j);
-                }
-
-                result[j] = s;
-            }
-        }
-
-        /// <summary>
         /// Multiplies this matrix with another matrix and places the results into the result matrix.
         /// </summary>
         /// <param name="other">The matrix to multiply with.</param>


### PR DESCRIPTION
This aims to save some redundant coding. 
LeftMultiply with vector is exactly the same as TransposeThisAndMultiply() with vector. Proof:

(Matrix^T \* vector)^T = vector^T \* Matrix

The transpose of a vector is only for strict mathematics row-column consistency but we don't actually care about the transpose of a vector in calculations. Therefore:

Matrix^T \* vector = vector \* Matrix

LeftMultiply() is changed to a protected method (from protected abstract) and it now calls TransposeThisAndMultiply() and cannot be overridden. TransposeThisAndMultiply() has unit tests so it was chosen as the "main" method. Overrides of LeftMultiply were removed, because now only TransposeThisAndMultiply() needs to be overridden.
