### PR TITLE
Extension of ChiSquare distribution to support non-integer degrees of freedom

### DIFF
--- a/src/Numerics/Distributions/Continuous/ChiSquare.cs
+++ b/src/Numerics/Distributions/Continuous/ChiSquare.cs
@@ -274,14 +274,20 @@ namespace MathNet.Numerics.Distributions
         /// <returns>a random number from the distribution.</returns>
         private static double DoSample(Random rnd, double dof)
         {
-            double sum = 0;
-            var n = (int)dof;
-            for (var i = 0; i < n; i++)
+            //Use the simple method if the dof is an integer anyway
+            if (Math.Floor(dof) == dof)
             {
-                sum += Math.Pow(Normal.Sample(rnd, 0.0, 1.0), 2);
+                double sum = 0;
+                var n = (int)dof;
+                for (var i = 0; i < n; i++)
+                {
+                    sum += Math.Pow(Normal.Sample(rnd, 0.0, 1.0), 2);
+                }
+                return sum;
             }
-
-            return sum;
+            //Call the gamma function (see http://en.wikipedia.org/wiki/Gamma_distribution#Specializations
+            //for a justification)
+            return Gamma.Sample(rnd, dof / 2.0, .5);
         }
 
         /// <summary>


### PR DESCRIPTION
The current implementation of ChiSquare.DoSample only returns representative samples if the number of degrees of freedom is an integer even though the parameter supplied in the constructor is a double. 

The Gamma distribution reduces to the ChiSquare distribution for a particular choice of parameters (http://en.wikipedia.org/wiki/Gamma_distribution#Specializations).

In the pull request the function private static double DoSample(Random rnd, double dof) is modified to draw a sample from the Gamma distribution if the dof is not an integer such as to provide support for non-integer dof.
