### PR TITLE
Sparse Vector DoAdd Scalar fix

### DIFF
--- a/src/Numerics/LinearAlgebra/Complex/SparseVector.cs
+++ b/src/Numerics/LinearAlgebra/Complex/SparseVector.cs
@@ -357,6 +357,8 @@ namespace MathNet.Numerics.LinearAlgebra.Complex
 
         /// <summary>
         /// Adds a scalar to each element of the vector and stores the result in the result vector.
+        /// Warning, the new 'sparse vector' with a non-zero scalar added to it will be a 100% filled
+        /// sparse vector and very inefficient. Would be better to work with a dense vector instead.
         /// </summary>
         /// <param name="scalar">
         /// The scalar to add.
@@ -378,10 +380,25 @@ namespace MathNet.Numerics.LinearAlgebra.Complex
 
             if (ReferenceEquals(this, result))
             {
-                CommonParallel.For(
-                    0,
-                    NonZerosCount,
-                    index => _nonZeroValues[index] += scalar);
+                //populate a new vector with the scalar   
+                var vnonZeroValues = new Complex[this.Count];
+                var vnonZeroIndices = new int[this.Count];
+                for (int index = 0; index < this.Count; index++)
+                {
+                    vnonZeroIndices[index] = index;
+                    vnonZeroValues[index] = scalar;
+                }
+
+                //populate the non zero values from this
+                for (int j = 0; j < this.NonZerosCount; j++)
+                {
+                    vnonZeroValues[this._nonZeroIndices[j]] = this._nonZeroValues[j] + scalar;
+                }
+
+                //assign this vectors arrary to the new arrays. 
+                this._nonZeroValues = vnonZeroValues;
+                this._nonZeroIndices = vnonZeroIndices;
+                this.NonZerosCount = this.Count;
             }
             else
             {

--- a/src/Numerics/LinearAlgebra/Complex32/SparseVector.cs
+++ b/src/Numerics/LinearAlgebra/Complex32/SparseVector.cs
@@ -387,6 +387,8 @@ namespace MathNet.Numerics.LinearAlgebra.Complex32
 
         /// <summary>
         /// Adds a scalar to each element of the vector and stores the result in the result vector.
+        /// Warning, the new 'sparse vector' with a non-zero scalar added to it will be a 100% filled
+        /// sparse vector and very inefficient. Would be better to work with a dense vector instead.
         /// </summary>
         /// <param name="scalar">
         /// The scalar to add.
@@ -408,10 +410,26 @@ namespace MathNet.Numerics.LinearAlgebra.Complex32
 
             if (ReferenceEquals(this, result))
             {
-                CommonParallel.For(
-                    0,
-                    NonZerosCount,
-                    index => _nonZeroValues[index] += scalar);
+                //populate a new vector with the scalar   
+                var vnonZeroValues = new Complex32[this.Count];
+                var vnonZeroIndices = new int[this.Count];
+                for (int index = 0; index < this.Count; index++)
+                {
+                    vnonZeroIndices[index] = index;
+                    vnonZeroValues[index] = scalar;
+                }
+
+                //populate the non zero values from this
+                for (int j = 0; j < this.NonZerosCount; j++)
+                {
+                    vnonZeroValues[this._nonZeroIndices[j]] = this._nonZeroValues[j] + scalar;
+                }
+
+                //assign this vectors arrary to the new arrays. 
+                this._nonZeroValues = vnonZeroValues;
+                this._nonZeroIndices = vnonZeroIndices;
+                this.NonZerosCount = this.Count;
+
             }
             else
             {

--- a/src/Numerics/LinearAlgebra/Double/SparseVector.cs
+++ b/src/Numerics/LinearAlgebra/Double/SparseVector.cs
@@ -305,6 +305,8 @@ namespace MathNet.Numerics.LinearAlgebra.Double
 
         /// <summary>
         /// Adds a scalar to each element of the vector and stores the result in the result vector.
+        /// Warning, the new 'sparse vector' with a non-zero scalar added to it will be a 100% filled
+        /// sparse vector and very inefficient. Would be better to work with a dense vector instead.
         /// </summary>
         /// <param name="scalar">
         /// The scalar to add.
@@ -326,10 +328,26 @@ namespace MathNet.Numerics.LinearAlgebra.Double
 
             if (ReferenceEquals(this, result))
             {
-                CommonParallel.For(
-                    0,
-                    NonZerosCount,
-                    index => _nonZeroValues[index] += scalar);                
+                //populate a new vector with the scalar   
+                var vnonZeroValues = new double[this.Count];
+                var vnonZeroIndices = new int[this.Count];
+                for (int index = 0; index < this.Count; index++)
+                {
+                    vnonZeroIndices[index] = index;
+                    vnonZeroValues[index] = scalar;
+                }
+
+                //populate the non zero values from this
+                for (int j = 0; j < this.NonZerosCount; j++)
+                {
+                    vnonZeroValues[this._nonZeroIndices[j]] = this._nonZeroValues[j] + scalar;
+                }
+
+                //assign this vectors arrary to the new arrays. 
+                this._nonZeroValues = vnonZeroValues;
+                this._nonZeroIndices = vnonZeroIndices;
+                this.NonZerosCount = this.Count;
+
             }
             else
             {

--- a/src/Numerics/LinearAlgebra/Single/SparseVector.cs
+++ b/src/Numerics/LinearAlgebra/Single/SparseVector.cs
@@ -335,6 +335,8 @@ namespace MathNet.Numerics.LinearAlgebra.Single
 
         /// <summary>
         /// Adds a scalar to each element of the vector and stores the result in the result vector.
+        /// Warning, the new 'sparse vector' with a non-zero scalar added to it will be a 100% filled
+        /// sparse vector and very inefficient. Would be better to work with a dense vector instead.
         /// </summary>
         /// <param name="scalar">
         /// The scalar to add.
@@ -356,11 +358,27 @@ namespace MathNet.Numerics.LinearAlgebra.Single
 
             if (ReferenceEquals(this, result))
             {
-                CommonParallel.For(
-                    0,
-                    NonZerosCount,
-                    index => _nonZeroValues[index] += scalar);
+                //populate a new vector with the scalar   
+                var vnonZeroValues = new float[this.Count];
+                var vnonZeroIndices = new int[this.Count];
+                for (int index = 0; index < this.Count; index++)
+                {
+                    vnonZeroIndices[index] = index;
+                    vnonZeroValues[index] = scalar;
+                }
+
+                //populate the non zero values from this
+                for (int j = 0; j < this.NonZerosCount; j++)
+                {
+                    vnonZeroValues[this._nonZeroIndices[j]] = this._nonZeroValues[j] + scalar;
+                }
+
+                //assign this vectors arrary to the new arrays. 
+                this._nonZeroValues = vnonZeroValues;
+                this._nonZeroIndices = vnonZeroIndices;
+                this.NonZerosCount = this.Count;
             }
+
             else
             {
                 for (var index = 0; index < Count; index++)


### PR DESCRIPTION
Unit tested using existing tests and passed.
With this there are no more errors showing in the current LinearAlgebra unit tests- only inconclusives.

I did not use Parallel For and kept it simple.
Reason is that adding a scalar to a sparse Vector is highly inefficient and is probably not applicable to code sections where speed is of the essence.  ((should possibly even write to a run time warning log ??))
