### PR TITLE
Issue #15: One Pass Statistics

### DIFF
--- a/src/Numerics/Statistics/Statistics.cs
+++ b/src/Numerics/Statistics/Statistics.cs
@@ -32,6 +32,7 @@ namespace MathNet.Numerics.Statistics
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using Properties;
 
     /// <summary>
@@ -455,7 +456,7 @@ namespace MathNet.Numerics.Statistics
             if (dataArray.Count % 2 == 0)
             {
                 double lower = OrderSelect(dataArray, 0, dataArray.Count - 1, index - 1);
-                double upper = OrderSelect(dataArray, 0, dataArray.Count - 1, index);
+                double upper = dataArray.Skip(index - 1).Minimum();
                 return (lower + upper) / 2.0;
             }
 
@@ -543,12 +544,23 @@ namespace MathNet.Numerics.Statistics
                     return samples[left];
                 }
 
-                // The pivot point.
+                
+                // The pivot point. Choose median of left, right and center
+                //to be the pivot and arrange so that
+                //samples[left]<=samples[right]<=samples[center]
+                int center = (left + right) / 2;
+                if (samples[center] < samples[left])
+                    Sorting.Swap(samples, left, center);
+                if (samples[center] < samples[right])
+                    Sorting.Swap(samples, right, center);
+                if (samples[right] < samples[left])
+                    Sorting.Swap(samples, right, left);
+
                 double pivot = samples[right];
 
                 // The partioning code.
-                int i = left - 1;
-                for (int j = left; j <= right - 1; j++)
+                int i = left;
+                for (int j = left+1; j <= right - 1; j++)
                 {
                     if (samples[j] <= pivot)
                     {


### PR DESCRIPTION
Response to Issue #15: 
Changed the computations of statistics in the DescriptiveStatistics and Correlation classes to the one pass algorithm based on J. Bannett et al. Numerically Stable, Single Pass, Parallel Statistics Algorithms. Proc. IEEE International Conference on Cluster Computing. (2009). (Although DescriptiveStatistics still needs two passes, one for computing mean, variances, etc. and the other one for computing median, whereas the current version needs three passes, first compute mean, then the other statistics except median, then compute median) The ones in the static Statistics class are already one pass. 

Changed the choice of pivot in the private OrderSelect method in the Statistics class. The current choice of pivot performs badly with a partially sorted list, which is a problem when using it on a large dataset with even number of entries. (because in the Median method, OrderSelect is called twice when the number of entries are even and in the first call, it partially sorted the buffer set, which leads to poor performance in the second call) 

All these changes have passed the existing unit tests. 
