### PR TITLE
Mersenne Twister returns not [0.0, 1.0) but [0.0, 1.0]

### DIFF
--- a/src/Numerics/Random/MersenneTwister.cs
+++ b/src/Numerics/Random/MersenneTwister.cs
@@ -98,7 +98,7 @@ namespace MathNet.Numerics.Random
         /// <summary>
         /// Mersenne twister constant.
         /// </summary>
-        private const double _reciprocal = 1.0/4294967295.0;
+        private const double _reciprocal = 1.0/4294967296.0;
 
         /// <summary>
         /// Mersenne twister constant.


### PR DESCRIPTION
This patch ensures the random number is less than 1.0.
