### PR TITLE
Fixes Incorrect Matrix Foldback with Test.

### DIFF
--- a/src/FSharp/Matrix.fs
+++ b/src/FSharp/Matrix.fs
@@ -52,7 +52,7 @@ module Matrix =
         let m = A.ColumnCount
         let mutable acc = acc0
         for i in n-1 .. -1 .. 0 do
-            for j in n-1 .. -1 .. 0 do
+            for j in m-1 .. -1 .. 0 do
                 acc <- f (A.Item(i,j)) acc
         acc
 

--- a/src/FSharpUnitTests/Program.fs
+++ b/src/FSharpUnitTests/Program.fs
@@ -106,6 +106,8 @@ let MatrixTests =
 
     /// A small uniform vector.
     let smallM = new DenseMatrix( Array2D.create 2 2 0.3 )
+    let failingFoldBackM = DenseMatrix.init 2 3 (fun i j -> 1.0)
+
 
     /// A large vector with increasingly large entries
     let largeM = new DenseMatrix( Array2D.init 100 100 (fun i j -> float i * 100.0 + float j) )
@@ -115,6 +117,8 @@ let MatrixTests =
             (Matrix.fold (fun a b -> a - b) 0.0 smallM |> should equal -1.2)
         spec "Matrix.foldBack"
             (Matrix.foldBack (fun a b -> a - b) 0.0 smallM |> should equal 0.0)
+        spec "Matrix.foldBackSummation"
+            (Matrix.foldBack( fun a b -> a + b) 0.0 failingFoldBackM |> should equal 6.0)
         spec "Matrix.foldi"
             (Matrix.foldi (fun i j acc x -> acc + x + float (i+j)) 0.0 smallM |> should equal 5.2)
         spec "Matrix.toArray2"


### PR DESCRIPTION
FoldBack was incorrect because of incorrect indexing.

Tests did not detect this because the matrix was square.
