### PR TITLE
SparseMatrix is now Serializable

### DIFF
--- a/src/Numerics/LinearAlgebra/Storage/MatrixStorage.cs
+++ b/src/Numerics/LinearAlgebra/Storage/MatrixStorage.cs
@@ -3,6 +3,7 @@ using MathNet.Numerics.Properties;
 
 namespace MathNet.Numerics.LinearAlgebra.Storage
 {
+	[Serializable]
     public abstract partial class MatrixStorage<T> : IEquatable<MatrixStorage<T>>
         where T : struct, IEquatable<T>, IFormattable
     {

--- a/src/Numerics/LinearAlgebra/Storage/SparseCompressedRowMatrixStorage.cs
+++ b/src/Numerics/LinearAlgebra/Storage/SparseCompressedRowMatrixStorage.cs
@@ -4,6 +4,7 @@ using MathNet.Numerics.Properties;
 
 namespace MathNet.Numerics.LinearAlgebra.Storage
 {
+	[Serializable]
     public class SparseCompressedRowMatrixStorage<T> : MatrixStorage<T>
         where T : struct, IEquatable<T>, IFormattable
     {


### PR DESCRIPTION
MathNet.Numerics.LinearAlgebra.Storage.MatrixStorage and
MathNet.Numerics.LinearAlgebra.Storage.SparseCompressedRowMatrixStorage
have been marked as Serializable.

Even though SparseMatrix was marked as Serializable it didn't work because some member variables were not marked as well. 
