### PR TITLE
minor cleanup on mkl project

### DIFF
--- a/src/NativeWrappers/Common/wrapper_common.h
+++ b/src/NativeWrappers/Common/wrapper_common.h
@@ -1,5 +1,5 @@
-#ifndef COMMON_H
-#define COMMON_H
+#ifndef WRAPPER_COMMON_H
+#define WRAPPER_COMMON_H
 
 #ifdef _WINDOWS
 	#define DLLEXPORT __declspec( dllexport )

--- a/src/NativeWrappers/MKL/lapack.h
+++ b/src/NativeWrappers/MKL/lapack.h
@@ -1,8 +1,0 @@
-#ifndef LAPACK_H
-#define LAPACK_H
-
-//#include "blas.h"
-#include "mkl_lapack.h"
-
-#endif 
-

--- a/src/NativeWrappers/Windows/MKL/MKLWrapper.vcxproj
+++ b/src/NativeWrappers/Windows/MKL/MKLWrapper.vcxproj
@@ -104,7 +104,7 @@
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(CompilerPathForVC)\libiomp5md.dll" $(OutDir)</Command>
+      <Command>copy "$(INTEL_DEV_REDIST)\redist\$(IntelPlatform)\compiler\libiomp5md.dll" $(OutDir)</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -130,7 +130,7 @@
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(CompilerPathForVC)\libiomp5md.dll" $(OutDir)</Command>
+      <Command>copy "$(INTEL_DEV_REDIST)\redist\$(IntelPlatform)\compiler\libiomp5md.dll" $(OutDir)</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -155,7 +155,7 @@
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(CompilerPathForVC)\libiomp5md.dll" $(OutDir)</Command>
+      <Command>copy "$(INTEL_DEV_REDIST)\redist\$(IntelPlatform)\compiler\libiomp5md.dll" $(OutDir)</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -183,7 +183,7 @@
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(CompilerPathForVC)\libiomp5md.dll" $(OutDir)</Command>
+      <Command>copy "$(INTEL_DEV_REDIST)\redist\$(IntelPlatform)\compiler\libiomp5md.dll" $(OutDir)</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -194,7 +194,6 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Common\wrapper_common.h" />
-    <ClInclude Include="..\..\MKL\lapack.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\Common\resource.rc" />

--- a/src/NativeWrappers/Windows/MKL/MKLWrapper.vcxproj.filters
+++ b/src/NativeWrappers/Windows/MKL/MKLWrapper.vcxproj.filters
@@ -29,9 +29,6 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\MKL\lapack.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\Common\wrapper_common.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/src/NativeWrappers/Windows/NativeWrappers.sln
+++ b/src/NativeWrappers/Windows/NativeWrappers.sln
@@ -3,6 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Common", "Common", "{5A0892FF-82CE-40FC-BCE1-73810C615F52}"
 	ProjectSection(SolutionItems) = preProject
+		..\Common\lapack_common.h = ..\Common\lapack_common.h
 		..\Common\resource.h = ..\Common\resource.h
 		..\Common\resource.rc = ..\Common\resource.rc
 		..\Common\WindowsDLL.cpp = ..\Common\WindowsDLL.cpp


### PR DESCRIPTION
libiomp5md.dll is now copied from intel's redist directory
added a common array clone function to simplify cloning
moved some functions to a header file so could eventually use them in an ATLAS project 
