### PR TITLE
MathNet.Numerics.Resources to public visibility

### DIFF
--- a/src/Numerics/Properties/Resources.Designer.cs
+++ b/src/Numerics/Properties/Resources.Designer.cs
@@ -22,7 +22,7 @@ namespace MathNet.Numerics.Properties {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources {
+    public class Resources {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
@@ -63,7 +63,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The array arguments must have the same length..
         /// </summary>
-        internal static string ArgumentArraysSameLength {
+        public static string ArgumentArraysSameLength {
             get {
                 return ResourceManager.GetString("ArgumentArraysSameLength", resourceCulture);
             }
@@ -72,7 +72,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The given array is the wrong length. Should be {0}..
         /// </summary>
-        internal static string ArgumentArrayWrongLength {
+        public static string ArgumentArrayWrongLength {
             get {
                 return ResourceManager.GetString("ArgumentArrayWrongLength", resourceCulture);
             }
@@ -81,7 +81,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The argument must be between 0 and 1..
         /// </summary>
-        internal static string ArgumentBetween0And1 {
+        public static string ArgumentBetween0And1 {
             get {
                 return ResourceManager.GetString("ArgumentBetween0And1", resourceCulture);
             }
@@ -90,7 +90,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Value cannot be in the range -1 &lt; x &lt; 1..
         /// </summary>
-        internal static string ArgumentCannotBeBetweenOneAndNegativeOne {
+        public static string ArgumentCannotBeBetweenOneAndNegativeOne {
             get {
                 return ResourceManager.GetString("ArgumentCannotBeBetweenOneAndNegativeOne", resourceCulture);
             }
@@ -99,7 +99,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Value must be even..
         /// </summary>
-        internal static string ArgumentEven {
+        public static string ArgumentEven {
             get {
                 return ResourceManager.GetString("ArgumentEven", resourceCulture);
             }
@@ -108,7 +108,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The histogram does not contains the value..
         /// </summary>
-        internal static string ArgumentHistogramContainsNot {
+        public static string ArgumentHistogramContainsNot {
             get {
                 return ResourceManager.GetString("ArgumentHistogramContainsNot", resourceCulture);
             }
@@ -117,7 +117,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Value is expected to be between {0} and {1} (including {0} and {1})..
         /// </summary>
-        internal static string ArgumentInIntervalXYInclusive {
+        public static string ArgumentInIntervalXYInclusive {
             get {
                 return ResourceManager.GetString("ArgumentInIntervalXYInclusive", resourceCulture);
             }
@@ -126,7 +126,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to At least one item of {0} is a null reference (Nothing in Visual Basic)..
         /// </summary>
-        internal static string ArgumentItemNull {
+        public static string ArgumentItemNull {
             get {
                 return ResourceManager.GetString("ArgumentItemNull", resourceCulture);
             }
@@ -135,7 +135,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Value must be greater than or equal to one..
         /// </summary>
-        internal static string ArgumentLessThanOne {
+        public static string ArgumentLessThanOne {
             get {
                 return ResourceManager.GetString("ArgumentLessThanOne", resourceCulture);
             }
@@ -144,7 +144,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to han the given upper bound..
         /// </summary>
-        internal static string ArgumentLowerBoundLargerThanUpperBound {
+        public static string ArgumentLowerBoundLargerThanUpperBound {
             get {
                 return ResourceManager.GetString("ArgumentLowerBoundLargerThanUpperBound", resourceCulture);
             }
@@ -153,7 +153,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Matrix dimensions must agree..
         /// </summary>
-        internal static string ArgumentMatrixDimensions {
+        public static string ArgumentMatrixDimensions {
             get {
                 return ResourceManager.GetString("ArgumentMatrixDimensions", resourceCulture);
             }
@@ -162,7 +162,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Matrix dimensions must agree: {0}..
         /// </summary>
-        internal static string ArgumentMatrixDimensions1 {
+        public static string ArgumentMatrixDimensions1 {
             get {
                 return ResourceManager.GetString("ArgumentMatrixDimensions1", resourceCulture);
             }
@@ -171,7 +171,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Matrix dimensions must agree: op1 is {0}, op2 is {1}..
         /// </summary>
-        internal static string ArgumentMatrixDimensions2 {
+        public static string ArgumentMatrixDimensions2 {
             get {
                 return ResourceManager.GetString("ArgumentMatrixDimensions2", resourceCulture);
             }
@@ -180,7 +180,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Matrix dimensions must agree: op1 is {0}, op2 is {1}, op3 is {2}..
         /// </summary>
-        internal static string ArgumentMatrixDimensions3 {
+        public static string ArgumentMatrixDimensions3 {
             get {
                 return ResourceManager.GetString("ArgumentMatrixDimensions3", resourceCulture);
             }
@@ -189,7 +189,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The requested matrix does not exist..
         /// </summary>
-        internal static string ArgumentMatrixDoesNotExist {
+        public static string ArgumentMatrixDoesNotExist {
             get {
                 return ResourceManager.GetString("ArgumentMatrixDoesNotExist", resourceCulture);
             }
@@ -198,7 +198,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The matrix indices must not be out of range of the given matrix..
         /// </summary>
-        internal static string ArgumentMatrixIndexOutOfRange {
+        public static string ArgumentMatrixIndexOutOfRange {
             get {
                 return ResourceManager.GetString("ArgumentMatrixIndexOutOfRange", resourceCulture);
             }
@@ -207,7 +207,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Matrix must not be rank deficient..
         /// </summary>
-        internal static string ArgumentMatrixNotRankDeficient {
+        public static string ArgumentMatrixNotRankDeficient {
             get {
                 return ResourceManager.GetString("ArgumentMatrixNotRankDeficient", resourceCulture);
             }
@@ -216,7 +216,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Matrix must not be singular..
         /// </summary>
-        internal static string ArgumentMatrixNotSingular {
+        public static string ArgumentMatrixNotSingular {
             get {
                 return ResourceManager.GetString("ArgumentMatrixNotSingular", resourceCulture);
             }
@@ -225,7 +225,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Matrix must be positive definite..
         /// </summary>
-        internal static string ArgumentMatrixPositiveDefinite {
+        public static string ArgumentMatrixPositiveDefinite {
             get {
                 return ResourceManager.GetString("ArgumentMatrixPositiveDefinite", resourceCulture);
             }
@@ -234,7 +234,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Matrix column dimensions must agree..
         /// </summary>
-        internal static string ArgumentMatrixSameColumnDimension {
+        public static string ArgumentMatrixSameColumnDimension {
             get {
                 return ResourceManager.GetString("ArgumentMatrixSameColumnDimension", resourceCulture);
             }
@@ -243,7 +243,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Matrix row dimensions must agree..
         /// </summary>
-        internal static string ArgumentMatrixSameRowDimension {
+        public static string ArgumentMatrixSameRowDimension {
             get {
                 return ResourceManager.GetString("ArgumentMatrixSameRowDimension", resourceCulture);
             }
@@ -252,7 +252,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Matrix must have exactly one column..
         /// </summary>
-        internal static string ArgumentMatrixSingleColumn {
+        public static string ArgumentMatrixSingleColumn {
             get {
                 return ResourceManager.GetString("ArgumentMatrixSingleColumn", resourceCulture);
             }
@@ -261,7 +261,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Matrix must have exactly one column and row, thus have only one cell..
         /// </summary>
-        internal static string ArgumentMatrixSingleColumnRow {
+        public static string ArgumentMatrixSingleColumnRow {
             get {
                 return ResourceManager.GetString("ArgumentMatrixSingleColumnRow", resourceCulture);
             }
@@ -270,7 +270,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Matrix must have exactly one row..
         /// </summary>
-        internal static string ArgumentMatrixSingleRow {
+        public static string ArgumentMatrixSingleRow {
             get {
                 return ResourceManager.GetString("ArgumentMatrixSingleRow", resourceCulture);
             }
@@ -279,7 +279,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Matrix must be square..
         /// </summary>
-        internal static string ArgumentMatrixSquare {
+        public static string ArgumentMatrixSquare {
             get {
                 return ResourceManager.GetString("ArgumentMatrixSquare", resourceCulture);
             }
@@ -288,7 +288,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Matrix must be symmetric..
         /// </summary>
-        internal static string ArgumentMatrixSymmetric {
+        public static string ArgumentMatrixSymmetric {
             get {
                 return ResourceManager.GetString("ArgumentMatrixSymmetric", resourceCulture);
             }
@@ -297,7 +297,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Matrix must be symmetric positive definite..
         /// </summary>
-        internal static string ArgumentMatrixSymmetricPositiveDefinite {
+        public static string ArgumentMatrixSymmetricPositiveDefinite {
             get {
                 return ResourceManager.GetString("ArgumentMatrixSymmetricPositiveDefinite", resourceCulture);
             }
@@ -306,7 +306,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to In the specified range, the minimum is greater than maximum..
         /// </summary>
-        internal static string ArgumentMinValueGreaterThanMaxValue {
+        public static string ArgumentMinValueGreaterThanMaxValue {
             get {
                 return ResourceManager.GetString("ArgumentMinValueGreaterThanMaxValue", resourceCulture);
             }
@@ -315,7 +315,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Value must be positive..
         /// </summary>
-        internal static string ArgumentMustBePositive {
+        public static string ArgumentMustBePositive {
             get {
                 return ResourceManager.GetString("ArgumentMustBePositive", resourceCulture);
             }
@@ -324,7 +324,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Value must neither be infinite nor NaN..
         /// </summary>
-        internal static string ArgumentNotInfinityNaN {
+        public static string ArgumentNotInfinityNaN {
             get {
                 return ResourceManager.GetString("ArgumentNotInfinityNaN", resourceCulture);
             }
@@ -333,7 +333,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Value must not be negative (zero is ok)..
         /// </summary>
-        internal static string ArgumentNotNegative {
+        public static string ArgumentNotNegative {
             get {
                 return ResourceManager.GetString("ArgumentNotNegative", resourceCulture);
             }
@@ -342,7 +342,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to {0} is a null reference (Nothing in Visual Basic)..
         /// </summary>
-        internal static string ArgumentNull {
+        public static string ArgumentNull {
             get {
                 return ResourceManager.GetString("ArgumentNull", resourceCulture);
             }
@@ -351,7 +351,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Value must be odd..
         /// </summary>
-        internal static string ArgumentOdd {
+        public static string ArgumentOdd {
             get {
                 return ResourceManager.GetString("ArgumentOdd", resourceCulture);
             }
@@ -360,7 +360,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to {0} must be greater than {1}..
         /// </summary>
-        internal static string ArgumentOutOfRangeGreater {
+        public static string ArgumentOutOfRangeGreater {
             get {
                 return ResourceManager.GetString("ArgumentOutOfRangeGreater", resourceCulture);
             }
@@ -369,7 +369,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to {0} must be greater than or equal to {1}..
         /// </summary>
-        internal static string ArgumentOutOfRangeGreaterEqual {
+        public static string ArgumentOutOfRangeGreaterEqual {
             get {
                 return ResourceManager.GetString("ArgumentOutOfRangeGreaterEqual", resourceCulture);
             }
@@ -378,7 +378,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The chosen parameter set is invalid (probably some value is out of range)..
         /// </summary>
-        internal static string ArgumentParameterSetInvalid {
+        public static string ArgumentParameterSetInvalid {
             get {
                 return ResourceManager.GetString("ArgumentParameterSetInvalid", resourceCulture);
             }
@@ -387,7 +387,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The given expression does not represent a complex number..
         /// </summary>
-        internal static string ArgumentParseComplexNumber {
+        public static string ArgumentParseComplexNumber {
             get {
                 return ResourceManager.GetString("ArgumentParseComplexNumber", resourceCulture);
             }
@@ -396,7 +396,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Value must be positive (and not zero)..
         /// </summary>
-        internal static string ArgumentPositive {
+        public static string ArgumentPositive {
             get {
                 return ResourceManager.GetString("ArgumentPositive", resourceCulture);
             }
@@ -405,7 +405,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Size must be a Power of Two..
         /// </summary>
-        internal static string ArgumentPowerOfTwo {
+        public static string ArgumentPowerOfTwo {
             get {
                 return ResourceManager.GetString("ArgumentPowerOfTwo", resourceCulture);
             }
@@ -414,7 +414,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Size must be a Power of Two in every dimension..
         /// </summary>
-        internal static string ArgumentPowerOfTwoEveryDimension {
+        public static string ArgumentPowerOfTwoEveryDimension {
             get {
                 return ResourceManager.GetString("ArgumentPowerOfTwoEveryDimension", resourceCulture);
             }
@@ -423,7 +423,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The range between {0} and {1} must be less than or equal to {2}..
         /// </summary>
-        internal static string ArgumentRangeLessEqual {
+        public static string ArgumentRangeLessEqual {
             get {
                 return ResourceManager.GetString("ArgumentRangeLessEqual", resourceCulture);
             }
@@ -432,7 +432,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Arguments must be different objects..
         /// </summary>
-        internal static string ArgumentReferenceDifferent {
+        public static string ArgumentReferenceDifferent {
             get {
                 return ResourceManager.GetString("ArgumentReferenceDifferent", resourceCulture);
             }
@@ -441,7 +441,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Array must have exactly one dimension (and not be null)..
         /// </summary>
-        internal static string ArgumentSingleDimensionArray {
+        public static string ArgumentSingleDimensionArray {
             get {
                 return ResourceManager.GetString("ArgumentSingleDimensionArray", resourceCulture);
             }
@@ -450,7 +450,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Value is too large..
         /// </summary>
-        internal static string ArgumentTooLarge {
+        public static string ArgumentTooLarge {
             get {
                 return ResourceManager.GetString("ArgumentTooLarge", resourceCulture);
             }
@@ -459,7 +459,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Value is too large for the current iteration limit..
         /// </summary>
-        internal static string ArgumentTooLargeForIterationLimit {
+        public static string ArgumentTooLargeForIterationLimit {
             get {
                 return ResourceManager.GetString("ArgumentTooLargeForIterationLimit", resourceCulture);
             }
@@ -468,7 +468,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Type mismatch..
         /// </summary>
-        internal static string ArgumentTypeMismatch {
+        public static string ArgumentTypeMismatch {
             get {
                 return ResourceManager.GetString("ArgumentTypeMismatch", resourceCulture);
             }
@@ -477,7 +477,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Array length must be a multiple of {0}..
         /// </summary>
-        internal static string ArgumentVectorLengthsMultipleOf {
+        public static string ArgumentVectorLengthsMultipleOf {
             get {
                 return ResourceManager.GetString("ArgumentVectorLengthsMultipleOf", resourceCulture);
             }
@@ -486,7 +486,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to All vectors must have the same dimensionality..
         /// </summary>
-        internal static string ArgumentVectorsSameLength {
+        public static string ArgumentVectorsSameLength {
             get {
                 return ResourceManager.GetString("ArgumentVectorsSameLength", resourceCulture);
             }
@@ -495,7 +495,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The vector must have 3 dimensions..
         /// </summary>
-        internal static string ArgumentVectorThreeDimensional {
+        public static string ArgumentVectorThreeDimensional {
             get {
                 return ResourceManager.GetString("ArgumentVectorThreeDimensional", resourceCulture);
             }
@@ -504,7 +504,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The given array is too small. It must be at least {0} long..
         /// </summary>
-        internal static string ArrayTooSmall {
+        public static string ArrayTooSmall {
             get {
                 return ResourceManager.GetString("ArrayTooSmall", resourceCulture);
             }
@@ -513,7 +513,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Big endian files are not supported..
         /// </summary>
-        internal static string BigEndianNotSupported {
+        public static string BigEndianNotSupported {
             get {
                 return ResourceManager.GetString("BigEndianNotSupported", resourceCulture);
             }
@@ -522,7 +522,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The supplied collection is empty..
         /// </summary>
-        internal static string CollectionEmpty {
+        public static string CollectionEmpty {
             get {
                 return ResourceManager.GetString("CollectionEmpty", resourceCulture);
             }
@@ -531,7 +531,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Complex matrices are not supported..
         /// </summary>
-        internal static string ComplexMatricesNotSupported {
+        public static string ComplexMatricesNotSupported {
             get {
                 return ResourceManager.GetString("ComplexMatricesNotSupported", resourceCulture);
             }
@@ -540,7 +540,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to An algorithm failed to converge..
         /// </summary>
-        internal static string ConvergenceFailed {
+        public static string ConvergenceFailed {
             get {
                 return ResourceManager.GetString("ConvergenceFailed", resourceCulture);
             }
@@ -549,7 +549,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to This feature is not implemented yet (but is planned)..
         /// </summary>
-        internal static string FeaturePlannedButNotImplementedYet {
+        public static string FeaturePlannedButNotImplementedYet {
             get {
                 return ResourceManager.GetString("FeaturePlannedButNotImplementedYet", resourceCulture);
             }
@@ -558,7 +558,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The given file doesn&apos;t exist..
         /// </summary>
-        internal static string FileDoesNotExist {
+        public static string FileDoesNotExist {
             get {
                 return ResourceManager.GetString("FileDoesNotExist", resourceCulture);
             }
@@ -567,7 +567,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Sample points should be sorted in strictly ascending order.
         /// </summary>
-        internal static string Interpolation_Initialize_SamplePointsNotStrictlyAscendingOrder {
+        public static string Interpolation_Initialize_SamplePointsNotStrictlyAscendingOrder {
             get {
                 return ResourceManager.GetString("Interpolation_Initialize_SamplePointsNotStrictlyAscendingOrder", resourceCulture);
             }
@@ -576,7 +576,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to All sample points should be unique..
         /// </summary>
-        internal static string Interpolation_Initialize_SamplePointsNotUnique {
+        public static string Interpolation_Initialize_SamplePointsNotUnique {
             get {
                 return ResourceManager.GetString("Interpolation_Initialize_SamplePointsNotUnique", resourceCulture);
             }
@@ -585,7 +585,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Invalid parameterization for the distribution..
         /// </summary>
-        internal static string InvalidDistributionParameters {
+        public static string InvalidDistributionParameters {
             get {
                 return ResourceManager.GetString("InvalidDistributionParameters", resourceCulture);
             }
@@ -594,7 +594,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Invalid Left Boundary Condition..
         /// </summary>
-        internal static string InvalidLeftBoundaryCondition {
+        public static string InvalidLeftBoundaryCondition {
             get {
                 return ResourceManager.GetString("InvalidLeftBoundaryCondition", resourceCulture);
             }
@@ -603,7 +603,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The operation could not be performed because the accumulator is empty..
         /// </summary>
-        internal static string InvalidOperationAccumulatorEmpty {
+        public static string InvalidOperationAccumulatorEmpty {
             get {
                 return ResourceManager.GetString("InvalidOperationAccumulatorEmpty", resourceCulture);
             }
@@ -612,7 +612,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The operation could not be performed because the histogram is empty..
         /// </summary>
-        internal static string InvalidOperationHistogramEmpty {
+        public static string InvalidOperationHistogramEmpty {
             get {
                 return ResourceManager.GetString("InvalidOperationHistogramEmpty", resourceCulture);
             }
@@ -621,7 +621,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Not enough points in the distribution..
         /// </summary>
-        internal static string InvalidOperationHistogramNotEnoughPoints {
+        public static string InvalidOperationHistogramNotEnoughPoints {
             get {
                 return ResourceManager.GetString("InvalidOperationHistogramNotEnoughPoints", resourceCulture);
             }
@@ -630,7 +630,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to No Samples Provided. Preparation Required..
         /// </summary>
-        internal static string InvalidOperationNoSamplesProvided {
+        public static string InvalidOperationNoSamplesProvided {
             get {
                 return ResourceManager.GetString("InvalidOperationNoSamplesProvided", resourceCulture);
             }
@@ -639,7 +639,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Invalid Right Boundary Condition..
         /// </summary>
-        internal static string InvalidRightBoundaryCondition {
+        public static string InvalidRightBoundaryCondition {
             get {
                 return ResourceManager.GetString("InvalidRightBoundaryCondition", resourceCulture);
             }
@@ -648,7 +648,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to ddd MMM dd HH:mm:ss yyyy.
         /// </summary>
-        internal static string MatlabDateHeaderFormat {
+        public static string MatlabDateHeaderFormat {
             get {
                 return ResourceManager.GetString("MatlabDateHeaderFormat", resourceCulture);
             }
@@ -657,7 +657,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The number of columns of a matrix must be positive..
         /// </summary>
-        internal static string MatrixColumnsMustBePositive {
+        public static string MatrixColumnsMustBePositive {
             get {
                 return ResourceManager.GetString("MatrixColumnsMustBePositive", resourceCulture);
             }
@@ -666,7 +666,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The number of rows of a matrix must be positive..
         /// </summary>
-        internal static string MatrixRowsMustBePositive {
+        public static string MatrixRowsMustBePositive {
             get {
                 return ResourceManager.GetString("MatrixRowsMustBePositive", resourceCulture);
             }
@@ -675,7 +675,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The number of rows or columns of a matrix must be positive..
         /// </summary>
-        internal static string MatrixRowsOrColumnsMustBePositive {
+        public static string MatrixRowsOrColumnsMustBePositive {
             get {
                 return ResourceManager.GetString("MatrixRowsOrColumnsMustBePositive", resourceCulture);
             }
@@ -684,7 +684,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Only 1 and 2 dimensional arrays are supported..
         /// </summary>
-        internal static string MoreThan2D {
+        public static string MoreThan2D {
             get {
                 return ResourceManager.GetString("MoreThan2D", resourceCulture);
             }
@@ -693,7 +693,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Data must contain at least {0} values..
         /// </summary>
-        internal static string MustContainAtLeast {
+        public static string MustContainAtLeast {
             get {
                 return ResourceManager.GetString("MustContainAtLeast", resourceCulture);
             }
@@ -702,7 +702,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Name cannot contain a space. name:  {0}.
         /// </summary>
-        internal static string NameCannotContainASpace {
+        public static string NameCannotContainASpace {
             get {
                 return ResourceManager.GetString("NameCannotContainASpace", resourceCulture);
             }
@@ -711,7 +711,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to {0} is not a supported type..
         /// </summary>
-        internal static string NotSupportedType {
+        public static string NotSupportedType {
             get {
                 return ResourceManager.GetString("NotSupportedType", resourceCulture);
             }
@@ -720,7 +720,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The two arguments can&apos;t be compared (maybe they are part of a partial ordering?).
         /// </summary>
-        internal static string PartialOrderException {
+        public static string PartialOrderException {
             get {
                 return ResourceManager.GetString("PartialOrderException", resourceCulture);
             }
@@ -729,7 +729,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The integer array does not represent a valid permutation..
         /// </summary>
-        internal static string PermutationAsIntArrayInvalid {
+        public static string PermutationAsIntArrayInvalid {
             get {
                 return ResourceManager.GetString("PermutationAsIntArrayInvalid", resourceCulture);
             }
@@ -738,7 +738,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The sampler&apos;s proposal distribution is not upper bounding the target density..
         /// </summary>
-        internal static string ProposalDistributionNoUpperBound {
+        public static string ProposalDistributionNoUpperBound {
             get {
                 return ResourceManager.GetString("ProposalDistributionNoUpperBound", resourceCulture);
             }
@@ -747,7 +747,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The number of rows must greater than or equal to the number of columns..
         /// </summary>
-        internal static string RowsLessThanColumns {
+        public static string RowsLessThanColumns {
             get {
                 return ResourceManager.GetString("RowsLessThanColumns", resourceCulture);
             }
@@ -756,7 +756,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The singular vectors were not computed..
         /// </summary>
-        internal static string SingularVectorsNotComputed {
+        public static string SingularVectorsNotComputed {
             get {
                 return ResourceManager.GetString("SingularVectorsNotComputed", resourceCulture);
             }
@@ -765,7 +765,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to This special case is not supported yet (but is planned)..
         /// </summary>
-        internal static string SpecialCasePlannedButNotImplementedYet {
+        public static string SpecialCasePlannedButNotImplementedYet {
             get {
                 return ResourceManager.GetString("SpecialCasePlannedButNotImplementedYet", resourceCulture);
             }
@@ -774,7 +774,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The given stop criterium already exist in the collection..
         /// </summary>
-        internal static string StopCriteriumDuplicate {
+        public static string StopCriteriumDuplicate {
             get {
                 return ResourceManager.GetString("StopCriteriumDuplicate", resourceCulture);
             }
@@ -783,7 +783,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to There is no stop criterium in the collection..
         /// </summary>
-        internal static string StopCriteriumMissing {
+        public static string StopCriteriumMissing {
             get {
                 return ResourceManager.GetString("StopCriteriumMissing", resourceCulture);
             }
@@ -792,7 +792,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to String parameter cannot be empty or null..
         /// </summary>
-        internal static string StringNullOrEmpty {
+        public static string StringNullOrEmpty {
             get {
                 return ResourceManager.GetString("StringNullOrEmpty", resourceCulture);
             }
@@ -801,7 +801,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to We only support sparse matrix with less than int.MaxValue elements..
         /// </summary>
-        internal static string TooManyElements {
+        public static string TooManyElements {
             get {
                 return ResourceManager.GetString("TooManyElements", resourceCulture);
             }
@@ -810,7 +810,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The moment of the distribution is undefined..
         /// </summary>
-        internal static string UndefinedMoment {
+        public static string UndefinedMoment {
             get {
                 return ResourceManager.GetString("UndefinedMoment", resourceCulture);
             }
@@ -819,7 +819,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to A user defined provider has not been specified..
         /// </summary>
-        internal static string UserDefinedProviderNotSpecified {
+        public static string UserDefinedProviderNotSpecified {
             get {
                 return ResourceManager.GetString("UserDefinedProviderNotSpecified", resourceCulture);
             }
@@ -828,7 +828,7 @@ namespace MathNet.Numerics.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The given work array is too small. Check work[0] for the corret size..
         /// </summary>
-        internal static string WorkArrayTooSmall {
+        public static string WorkArrayTooSmall {
             get {
                 return ResourceManager.GetString("WorkArrayTooSmall", resourceCulture);
             }


### PR DESCRIPTION
This pull request changes the Resources class and its members to public visibility.

The reason for this amendment is to allow others to extend the MathNet.Numerics library in
separate projects and .dll files (i.e. beyond the scope of internal visibility).  These extension projects may wish to call the Resources class of the MathNet project in order to achieve consistency in their behaviour.
