### PR TITLE
Avoid extreme performance reduction in wide/tall matrix multiplication

### DIFF
--- a/src/Numerics/Algorithms/LinearAlgebra/ManagedLinearAlgebraProvider.Double.cs
+++ b/src/Numerics/Algorithms/LinearAlgebra/ManagedLinearAlgebraProvider.Double.cs
@@ -674,7 +674,7 @@ namespace MathNet.Numerics.Algorithms.LinearAlgebra
         /// <param name="first">Indicates if this is the first recursion.</param>
         private static void CacheObliviousMatrixMultiply(Transpose transposeA, Transpose transposeB, double alpha, double[] matrixA, int shiftArow, int shiftAcol, double[] matrixB, int shiftBrow, int shiftBcol, double[] result, int shiftCrow, int shiftCcol, int m, int n, int k, int constM, int constN, int constK, bool first)
         {
-            if (m + n + k <= Control.ParallelizeOrder)
+            if (m + n <= Control.ParallelizeOrder)
             {
                 if ((int)transposeA > 111 && (int)transposeB > 111)
                 {


### PR DESCRIPTION
I empirically noticed that matrix multiplication was extremely slow for
the matrices I was using i.e. multiplications were taking minutes rather
than seconds. After tracking down the root of the problem, I found it
was in the CacheObliviousMatrixMultiply() implementation, specifically,
where the sum of the column/row dimensions were compared with the
Control.ParallelizeOrder variable.

For significantly skewed matrix multiplication (wide \* tall), the
parallelised redistribution greatly reduces performance. By removing the
'k' parameter from the comparison (where k is the number of columns in
the left matrix and the number of rows in the right) the performance is
improved drastically.

For perfectly square matrices, this change reduces performance slightly.

A unit test has been added to include some indicative matrix
multiplications (10x50000 \* 50000x10 and 1000x1000 \* 1000x1000).
