### PR TITLE
Minor adjustments to Fsharp.fproj to build with expected settings in Release-Signed configuration

### DIFF
--- a/src/FSharp/FSharp.fsproj
+++ b/src/FSharp/FSharp.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,6 +12,9 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <Name>FSharp</Name>
     <TargetFrameworkProfile />
+    <!-- Conditional Strong Name -->
+    <AssemblyOriginatorKeyFile>..\MathNet.Numerics.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly Condition=" '$(SignAssembly)' == '' ">false</SignAssembly>    
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,9 +33,13 @@
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>..\..\out\lib\Net40\MathNet.Numerics.FSharp.xml</DocumentationFile>
+    <!-- Conditional Strong Name: NO -->
+    <SignAssembly>false</SignAssembly>    
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DocumentationFile>MathNet.Numerics.FSharp.XML</DocumentationFile>
+    <!-- Conditional Strong Name: NO -->
+    <SignAssembly>false</SignAssembly>    
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release-Signed|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -41,7 +48,9 @@
     <DefineConstants>TRACE;STRONGNAME</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>..\..\out\lib\Net40\MathNet.Numerics.FSharp.xml</DocumentationFile>
-    <OutputPath>bin\Release-Signed\</OutputPath>
+    <OutputPath>..\..\out\lib\Net40\</OutputPath>
+    <!-- Conditional Strong Name: YES -->
+    <SignAssembly>true</SignAssembly>    
   </PropertyGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>


### PR DESCRIPTION
- make MathNet.Numerics.FSharp assembly signed when built in Release-Signed configuration
- set appropriate output folder for Release-Signed configuration
