### PR TITLE
Incorrect values are passed to sampleUnchecked inside Stable.Sample static methods

### DIFF
--- a/src/Numerics/Distributions/Continuous/Stable.cs
+++ b/src/Numerics/Distributions/Continuous/Stable.cs
@@ -518,7 +518,7 @@ namespace MathNet.Numerics.Distributions
                 throw new ArgumentOutOfRangeException(Resources.InvalidDistributionParameters);
             }
 
-            return SampleUnchecked(rnd, location, scale, scale, location);
+            return SampleUnchecked(rnd, alpha, beta, scale, location);
         }
 
         /// <summary>
@@ -539,7 +539,7 @@ namespace MathNet.Numerics.Distributions
 
             while (true)
             {
-                yield return SampleUnchecked(rnd, location, scale, scale, location);
+                yield return SampleUnchecked(rnd, alpha, beta, scale, location);
             }
         }
     }


### PR DESCRIPTION
The issue occured generating Stable(alpha, 1, 1, 0) (see example plot for alpha=0.5 at http://en.wikipedia.org/wiki/Stable_distribution)
Further investigation shown that location is passed instead of alpha into SampleUnchecked inside Stable.Sample static methods
