### PR TITLE
Fixed indexing bug in Numerics.Distance

### DIFF
--- a/src/Numerics/Distance.cs
+++ b/src/Numerics/Distance.cs
@@ -217,7 +217,7 @@ namespace MathNet.Numerics
         {
             if (a.Length != b.Length) throw new ArgumentOutOfRangeException("b");
             double max = Math.Abs(a[0] - b[0]);
-            for (int i = 1; i < a.Length; i++)
+            for (int i = 0; i < a.Length; i++)
             {
                 var next = Math.Abs(a[i] - b[i]);
                 if (next > max)
@@ -235,7 +235,7 @@ namespace MathNet.Numerics
         {
             if (a.Length != b.Length) throw new ArgumentOutOfRangeException("b");
             float max = Math.Abs(a[0] - b[0]);
-            for (int i = 1; i < a.Length; i++)
+            for (int i = 0; i < a.Length; i++)
             {
                 var next = Math.Abs(a[i] - b[i]);
                 if (next > max)


### PR DESCRIPTION
Indexing started at index 1 in Distance.Hamming and Distance.Chebyshev. This is now fixed so that indexing will start at index 0.
Fix for issue #220
