### PR TITLE
MatrixNormal density computation switched row and column covariance

### DIFF
--- a/src/Numerics/Distributions/MatrixNormal.cs
+++ b/src/Numerics/Distributions/MatrixNormal.cs
@@ -205,7 +205,7 @@ namespace MathNet.Numerics.Distributions
             var cholV = _v.Cholesky();
             var cholK = _k.Cholesky();
 
-            return Math.Exp(-0.5*cholV.Solve(a.Transpose()*cholK.Solve(a)).Trace())
+            return Math.Exp(-0.5*cholK.Solve(a.Transpose()*cholV.Solve(a)).Trace())
                    /Math.Pow(2.0*Constants.Pi, x.RowCount*x.ColumnCount/2.0)
                    /Math.Pow(cholV.Determinant, x.RowCount/2.0)
                    /Math.Pow(cholK.Determinant, x.ColumnCount/2.0);


### PR DESCRIPTION
There was a bug in density of MatrixNormal distribution. It showed only when number of rows was different from number of columns. For example:

```
            let m = [|[|1.0; 1.0|]|] |> DenseMatrix.ofColumnArrays
            let v = Double.DenseMatrix.CreateIdentity 2
            let k = Double.DenseMatrix.CreateIdentity 1
            let dist = MatrixNormal(m, v, k)
            let sample = dist.Sample()   // sampling from the distribution works
            dist.Density(sample)   // crashes
```

In the implementation, row covariance and column covariance matrices were switched.  
