### PR TITLE
Added support for missing values to delimited reader and writter

### DIFF
--- a/src/Data/Text/DelimitedWriter.cs
+++ b/src/Data/Text/DelimitedWriter.cs
@@ -50,9 +50,11 @@ namespace MathNet.Numerics.Data.Text
         /// <param name="columnHeaders">Custom column header. Headers are only written if non-null and non-empty headers are provided. Default: null.</param>
         /// <param name="format">The number format to use on each element. Default: null.</param>
         /// <param name="formatProvider">The culture to use. Default: null.</param>
+        /// <param name="missingValue">A value that represents a missing value. If not null, then elemements of the matrix that have this value
+        /// are not written to the output file.</param>
         /// <exception cref="ArgumentNullException">If either <paramref name="matrix"/> or <paramref name="writer"/> is <c>null</c>.</exception>
         /// <typeparam name="T">The data type of the Matrix. It can be either: Double, Single, Complex, or Complex32.</typeparam>
-        public static void Write<T>(TextWriter writer, Matrix<T> matrix, string delimiter = "\t", IList<string> columnHeaders = null, string format = null, IFormatProvider formatProvider = null)
+        public static void Write<T>(TextWriter writer, Matrix<T> matrix, string delimiter = "\t", IList<string> columnHeaders = null, string format = null, IFormatProvider formatProvider = null, T? missingValue = null)
             where T : struct, IEquatable<T>, IFormattable
         {
             if (matrix == null)
@@ -78,20 +80,49 @@ namespace MathNet.Numerics.Data.Text
 
             var cols = matrix.ColumnCount - 1;
             var rows = matrix.RowCount - 1;
-            for (var i = 0; i < matrix.RowCount; i++)
+            if (!missingValue.HasValue)
             {
-                for (var j = 0; j < matrix.ColumnCount; j++)
+                for (var i = 0; i < matrix.RowCount; i++)
                 {
-                    writer.Write(matrix[i, j].ToString(format, formatProvider));
-                    if (j != cols)
+                    for (var j = 0; j < matrix.ColumnCount; j++)
                     {
-                        writer.Write(delimiter);
+                        writer.Write(matrix[i, j].ToString(format, formatProvider));
+
+                        if (j != cols)
+                        {
+                            writer.Write(delimiter);
+                        }
+                    }
+
+                    if (i != rows)
+                    {
+                        writer.Write(Environment.NewLine);
                     }
                 }
-
-                if (i != rows)
+            }
+            else
+            {
+                var missing = missingValue.Value;
+                
+                for (var i = 0; i < matrix.RowCount; i++)
                 {
-                    writer.Write(Environment.NewLine);
+                    for (var j = 0; j < matrix.ColumnCount; j++)
+                    {
+                        if (!matrix[i, j].Equals(missing))
+                        {
+                            writer.Write(matrix[i, j].ToString(format, formatProvider));
+                        }
+
+                        if (j != cols)
+                        {
+                            writer.Write(delimiter);
+                        }
+                    }
+
+                    if (i != rows)
+                    {
+                        writer.Write(Environment.NewLine);
+                    }
                 }
             }
         }
@@ -105,14 +136,16 @@ namespace MathNet.Numerics.Data.Text
         /// <param name="columnHeaders">Custom column header. Headers are only written if non-null and non-empty headers are provided. Default: null.</param>
         /// <param name="format">The number format to use on each element. Default: null.</param>
         /// <param name="formatProvider">The culture to use. Default: null.</param>
+        /// <param name="missingValue">A value that represents a missing value. If not null, then elemements of the matrix that have this value
+        /// are not written to the output file.</param>
         /// <exception cref="ArgumentNullException">If either <paramref name="matrix"/> or <paramref name="filePath"/> is <c>null</c>.</exception>
         /// <typeparam name="T">The data type of the Matrix. It can be either: Double, Single, Complex, or Complex32.</typeparam>
-        public static void Write<T>(string filePath, Matrix<T> matrix, string delimiter = "\t", IList<string> columnHeaders = null, string format = null, IFormatProvider formatProvider = null)
+        public static void Write<T>(string filePath, Matrix<T> matrix, string delimiter = "\t", IList<string> columnHeaders = null, string format = null, IFormatProvider formatProvider = null, T? missingValue = null)
             where T : struct, IEquatable<T>, IFormattable
         {
             using (var writer = new StreamWriter(filePath))
             {
-                Write(writer, matrix, delimiter: delimiter, columnHeaders: columnHeaders, format: format, formatProvider: formatProvider);
+                Write(writer, matrix, delimiter: delimiter, columnHeaders: columnHeaders, format: format, formatProvider: formatProvider, missingValue: missingValue);
             }
         }
 
@@ -125,14 +158,16 @@ namespace MathNet.Numerics.Data.Text
         /// <param name="columnHeaders">Custom column header. Headers are only written if non-null and non-empty headers are provided. Default: null.</param>
         /// <param name="format">The number format to use on each element. Default: null.</param>
         /// <param name="formatProvider">The culture to use. Default: null.</param>
+        /// <param name="missingValue">A value that represents a missing value. If not null, then elemements of the matrix that have this value
+        /// are not written to the output file.</param>
         /// <exception cref="ArgumentNullException">If either <paramref name="matrix"/> or <paramref name="stream"/> is <c>null</c>.</exception>
         /// <typeparam name="T">The data type of the Matrix. It can be either: Double, Single, Complex, or Complex32.</typeparam>
-        public static void Write<T>(Stream stream, Matrix<T> matrix, string delimiter = "\t", IList<string> columnHeaders = null, string format = null, IFormatProvider formatProvider = null)
+        public static void Write<T>(Stream stream, Matrix<T> matrix, string delimiter = "\t", IList<string> columnHeaders = null, string format = null, IFormatProvider formatProvider = null, T? missingValue = null)
             where T : struct, IEquatable<T>, IFormattable
         {
             using (var writer = new StreamWriter(stream))
             {
-                Write(writer, matrix, delimiter: delimiter, columnHeaders: columnHeaders, format: format, formatProvider: formatProvider);
+                Write(writer, matrix, delimiter: delimiter, columnHeaders: columnHeaders, format: format, formatProvider: formatProvider, missingValue: missingValue);
             }
         }
     }

--- a/src/DataUnitTests/Text/DelimitedReaderTests.cs
+++ b/src/DataUnitTests/Text/DelimitedReaderTests.cs
@@ -59,11 +59,11 @@ namespace MathNet.Numerics.Data.UnitTests.Text
             Assert.AreEqual(3, matrix.RowCount);
             Assert.AreEqual(3, matrix.ColumnCount);
             Assert.AreEqual(1.0, matrix[0, 0]);
-            Assert.AreEqual(0.0, matrix[0, 1]);
-            Assert.AreEqual(0.0, matrix[0, 2]);
+            Assert.AreEqual(double.NaN, matrix[0, 1]);
+            Assert.AreEqual(double.NaN, matrix[0, 2]);
             Assert.AreEqual(2.2, matrix[1, 0]);
             Assert.AreEqual(3.0, matrix[1, 1]);
-            Assert.AreEqual(0.0, matrix[1, 2]);
+            Assert.AreEqual(double.NaN, matrix[1, 2]);
             Assert.AreEqual(4.0, matrix[2, 0]);
             Assert.AreEqual(5.0, matrix[2, 1]);
             Assert.AreEqual(6.0, matrix[2, 2]);
@@ -79,15 +79,15 @@ namespace MathNet.Numerics.Data.UnitTests.Text
                        + "\"2.2\"\t\t0.3e1" + Environment.NewLine
                        + "'4'\t5\t6";
 
-            var matrix = DelimitedReader.Read<float>(new MemoryStream(Encoding.UTF8.GetBytes(data)), delimiter: "\t", formatProvider: CultureInfo.InvariantCulture);
+            var matrix = DelimitedReader.Read<float>(new MemoryStream(Encoding.UTF8.GetBytes(data)), delimiter: "\t", formatProvider: CultureInfo.InvariantCulture, missingValue:0.0f);
             Assert.AreEqual(3, matrix.RowCount);
             Assert.AreEqual(3, matrix.ColumnCount);
             Assert.AreEqual(1.0f, matrix[0, 0]);
             Assert.AreEqual(0.0f, matrix[0, 1]);
             Assert.AreEqual(0.0f, matrix[0, 2]);
             Assert.AreEqual(2.2f, matrix[1, 0]);
-            Assert.AreEqual(3.0f, matrix[1, 1]);
-            Assert.AreEqual(0.0f, matrix[1, 2]);
+            Assert.AreEqual(0.0f, matrix[1, 1]);
+            Assert.AreEqual(3.0f, matrix[1, 2]);
             Assert.AreEqual(4.0f, matrix[2, 0]);
             Assert.AreEqual(5.0f, matrix[2, 1]);
             Assert.AreEqual(6.0f, matrix[2, 2]);
@@ -103,7 +103,7 @@ namespace MathNet.Numerics.Data.UnitTests.Text
                        + "\"2.2\" 0.3e1" + Environment.NewLine
                        + "'4'   5      6" + Environment.NewLine;
 
-            var matrix = DelimitedReader.Read<float>(new MemoryStream(Encoding.UTF8.GetBytes(data)), formatProvider: CultureInfo.InvariantCulture);
+            var matrix = DelimitedReader.Read<float>(new MemoryStream(Encoding.UTF8.GetBytes(data)), formatProvider: CultureInfo.InvariantCulture, missingValue:0.0f);
             Assert.AreEqual(3, matrix.RowCount);
             Assert.AreEqual(3, matrix.ColumnCount);
             Assert.AreEqual(1.0f, matrix[0, 0]);
@@ -128,7 +128,7 @@ namespace MathNet.Numerics.Data.UnitTests.Text
                        + "\"2,2\".0,3e1" + Environment.NewLine
                        + "'4,0'.5,0.6,0" + Environment.NewLine;
 
-            var matrix = DelimitedReader.Read<double>(new MemoryStream(Encoding.UTF8.GetBytes(data)), delimiter: ".", hasHeaders: true, formatProvider: new CultureInfo("tr-TR"));
+            var matrix = DelimitedReader.Read<double>(new MemoryStream(Encoding.UTF8.GetBytes(data)), delimiter: ".", hasHeaders: true, formatProvider: new CultureInfo("tr-TR"), missingValue:0.0);
             Assert.AreEqual(3, matrix.RowCount);
             Assert.AreEqual(3, matrix.ColumnCount);
             Assert.AreEqual(1.0, matrix[0, 0]);
@@ -155,19 +155,20 @@ namespace MathNet.Numerics.Data.UnitTests.Text
                        + "'(4,-5)',5,6" + Environment.NewLine;
 
             var matrix = DelimitedReader.Read<Complex>(new StringReader(data), delimiter: ",", hasHeaders: true, formatProvider: CultureInfo.InvariantCulture);
+            var nan = new Complex(double.NaN, double.NaN);
             Assert.AreEqual(3, matrix.RowCount);
             Assert.AreEqual(3, matrix.ColumnCount);
             Assert.AreEqual(1.0, matrix[0, 0].Real);
             Assert.AreEqual(2.0, matrix[0, 0].Imaginary);
-            Assert.AreEqual((Complex) 0.0, matrix[0, 1]);
-            Assert.AreEqual((Complex) 0.0, matrix[0, 2]);
-            Assert.AreEqual((Complex) 2.2, matrix[1, 0]);
-            Assert.AreEqual((Complex) 3.0, matrix[1, 1]);
-            Assert.AreEqual((Complex) 0.0, matrix[1, 2]);
+            Assert.AreEqual(nan, matrix[0, 1]);
+            Assert.AreEqual(nan, matrix[0, 2]);
+            Assert.AreEqual((Complex)2.2, matrix[1, 0]);
+            Assert.AreEqual((Complex)3.0, matrix[1, 1]);
+            Assert.AreEqual(nan, matrix[1, 2]);
             Assert.AreEqual(4.0, matrix[2, 0].Real);
             Assert.AreEqual(-5.0, matrix[2, 0].Imaginary);
-            Assert.AreEqual((Complex) 5.0, matrix[2, 1]);
-            Assert.AreEqual((Complex) 6.0, matrix[2, 2]);
+            Assert.AreEqual((Complex)5.0, matrix[2, 1]);
+            Assert.AreEqual((Complex)6.0, matrix[2, 2]);
         }
 
         /// <summary>
@@ -181,7 +182,7 @@ namespace MathNet.Numerics.Data.UnitTests.Text
                        + "\"2.2\",0.3e1" + Environment.NewLine
                        + "'(4,-5)',5,6" + Environment.NewLine;
 
-            var matrix = DelimitedReader.Read<Complex32>(new MemoryStream(Encoding.UTF8.GetBytes(data)), delimiter: ",", hasHeaders: true, formatProvider: CultureInfo.InvariantCulture);
+            var matrix = DelimitedReader.Read<Complex32>(new MemoryStream(Encoding.UTF8.GetBytes(data)), delimiter: ",", hasHeaders: true, formatProvider: CultureInfo.InvariantCulture, missingValue:Complex32.Zero);
             Assert.AreEqual(3, matrix.RowCount);
             Assert.AreEqual(3, matrix.ColumnCount);
             Assert.AreEqual(1.0f, matrix[0, 0].Real);
@@ -208,8 +209,154 @@ namespace MathNet.Numerics.Data.UnitTests.Text
                        + "\"2.2\",0.3e1" + Environment.NewLine
                        + "'4',0,6" + Environment.NewLine;
 
-            var matrix = DelimitedReader.Read<double>(new StringReader(data), true, ",", true, CultureInfo.InvariantCulture);
+            var matrix = DelimitedReader.Read<double>(new StringReader(data), true, ",", true, CultureInfo.InvariantCulture, missingValue:0.0);
             Assert.IsTrue(matrix is LinearAlgebra.Double.SparseMatrix);
+            Assert.AreEqual(3, matrix.RowCount);
+            Assert.AreEqual(3, matrix.ColumnCount);
+            Assert.AreEqual(1.0, matrix[0, 0]);
+            Assert.AreEqual(0.0, matrix[0, 1]);
+            Assert.AreEqual(0.0, matrix[0, 2]);
+            Assert.AreEqual(2.2, matrix[1, 0]);
+            Assert.AreEqual(3.0, matrix[1, 1]);
+            Assert.AreEqual(0.0, matrix[1, 2]);
+            Assert.AreEqual(4.0, matrix[2, 0]);
+            Assert.AreEqual(0.0, matrix[2, 1]);
+            Assert.AreEqual(6.0, matrix[2, 2]);
+        }
+
+
+        /// <summary>
+        /// Can parse comma delimited data with missing data.
+        /// </summary>
+        [Test]
+        public void CanParseMissingDataCommaDelimitedData()
+        {
+            var data = "a,b,c" + Environment.NewLine
+                       + ", , , ," + Environment.NewLine
+                       + "\"2.2\", ,   ,0.3e1" + Environment.NewLine
+                       + "'4',0,6" + Environment.NewLine
+                       + "," + Environment.NewLine
+                       + ",,3, 4" + Environment.NewLine
+                       + ",, , ,," + Environment.NewLine
+                       + ",,,,," + Environment.NewLine
+                       + ", ,,, ," + Environment.NewLine
+                       + ",  , , ,," + Environment.NewLine;
+
+            var matrix = DelimitedReader.Read<double>(new StringReader(data), false, ",", true, CultureInfo.InvariantCulture);
+
+            Assert.AreEqual(9, matrix.RowCount);
+            Assert.AreEqual(5, matrix.ColumnCount);
+            Assert.AreEqual(double.NaN, matrix[0, 0]);
+            Assert.AreEqual(double.NaN, matrix[0, 1]);
+            Assert.AreEqual(double.NaN, matrix[0, 2]);
+            Assert.AreEqual(double.NaN, matrix[0, 3]);
+            Assert.AreEqual(double.NaN, matrix[0, 4]);
+            Assert.AreEqual(2.2, matrix[1, 0]);
+            Assert.AreEqual(double.NaN, matrix[1, 1]);
+            Assert.AreEqual(double.NaN, matrix[1, 2]);
+            Assert.AreEqual(3.0, matrix[1, 3]);
+            Assert.AreEqual(double.NaN, matrix[1, 4]); 
+            Assert.AreEqual(4.0, matrix[2, 0]);
+            Assert.AreEqual(0.0, matrix[2, 1]);
+            Assert.AreEqual(6.0, matrix[2, 2]);
+            Assert.AreEqual(double.NaN, matrix[2, 3]);
+            Assert.AreEqual(double.NaN, matrix[2, 4]);
+            Assert.AreEqual(double.NaN, matrix[3, 0]);
+            Assert.AreEqual(double.NaN, matrix[3, 1]);
+            Assert.AreEqual(double.NaN, matrix[3, 2]);
+            Assert.AreEqual(double.NaN, matrix[3, 3]);
+            Assert.AreEqual(double.NaN, matrix[3, 4]); 
+            Assert.AreEqual(double.NaN, matrix[4, 0]);
+            Assert.AreEqual(double.NaN, matrix[4, 1]);
+            Assert.AreEqual(3.0, matrix[4, 2]);
+            Assert.AreEqual(4.0, matrix[4, 3]);
+            Assert.AreEqual(double.NaN, matrix[4, 4]);
+            Assert.AreEqual(double.NaN, matrix[5, 0]);
+            Assert.AreEqual(double.NaN, matrix[5, 1]);
+            Assert.AreEqual(double.NaN, matrix[5, 2]);
+            Assert.AreEqual(double.NaN, matrix[5, 3]);
+            Assert.AreEqual(double.NaN, matrix[5, 4]);
+            Assert.AreEqual(double.NaN, matrix[6, 0]);
+            Assert.AreEqual(double.NaN, matrix[6, 1]);
+            Assert.AreEqual(double.NaN, matrix[6, 2]);
+            Assert.AreEqual(double.NaN, matrix[6, 3]);
+            Assert.AreEqual(double.NaN, matrix[6, 4]);
+            Assert.AreEqual(double.NaN, matrix[7, 0]);
+            Assert.AreEqual(double.NaN, matrix[7, 1]);
+            Assert.AreEqual(double.NaN, matrix[7, 2]);
+            Assert.AreEqual(double.NaN, matrix[7, 3]);
+            Assert.AreEqual(double.NaN, matrix[7, 4]);
+            Assert.AreEqual(double.NaN, matrix[8, 0]);
+            Assert.AreEqual(double.NaN, matrix[8, 1]);
+            Assert.AreEqual(double.NaN, matrix[8, 2]);
+            Assert.AreEqual(double.NaN, matrix[8, 3]);
+            Assert.AreEqual(double.NaN, matrix[8, 4]);
+        }
+
+        /// <summary>
+        /// Can parse backslash delimited sparse data.
+        /// </summary>
+        [Test]
+        public void CanParseSparseBackSlashDelimitedData()
+        {
+            var data = "a\\b\\c" + Environment.NewLine
+                       + "1" + Environment.NewLine
+                       + "\"2.2\"\\0.3e1" + Environment.NewLine
+                       + "'4'\\0\\6" + Environment.NewLine;
+
+            var matrix = DelimitedReader.Read<double>(new StringReader(data), true, "\\", true, CultureInfo.InvariantCulture, missingValue:0.0);
+            Assert.IsTrue(matrix is LinearAlgebra.Double.SparseMatrix);
+            Assert.AreEqual(3, matrix.RowCount);
+            Assert.AreEqual(3, matrix.ColumnCount);
+            Assert.AreEqual(1.0, matrix[0, 0]);
+            Assert.AreEqual(0.0, matrix[0, 1]);
+            Assert.AreEqual(0.0, matrix[0, 2]);
+            Assert.AreEqual(2.2, matrix[1, 0]);
+            Assert.AreEqual(3.0, matrix[1, 1]);
+            Assert.AreEqual(0.0, matrix[1, 2]);
+            Assert.AreEqual(4.0, matrix[2, 0]);
+            Assert.AreEqual(0.0, matrix[2, 1]);
+            Assert.AreEqual(6.0, matrix[2, 2]);
+        }
+
+        /// <summary>
+        /// Can parse dash delimited sparse data.
+        /// </summary>
+        [Test]
+        public void CanParseSparseDashDelimitedData()
+        {
+            var data = "a-b-c" + Environment.NewLine
+                       + "1" + Environment.NewLine
+                       + "\"2.2\"-.3e1" + Environment.NewLine
+                       + "'4'-0-6" + Environment.NewLine;
+
+            var matrix = DelimitedReader.Read<double>(new StringReader(data), true, "-", true, CultureInfo.InvariantCulture, missingValue:0.0);
+            Assert.IsTrue(matrix is LinearAlgebra.Double.SparseMatrix);
+            Assert.AreEqual(3, matrix.RowCount);
+            Assert.AreEqual(3, matrix.ColumnCount);
+            Assert.AreEqual(1.0, matrix[0, 0]);
+            Assert.AreEqual(0.0, matrix[0, 1]);
+            Assert.AreEqual(0.0, matrix[0, 2]);
+            Assert.AreEqual(2.2, matrix[1, 0]);
+            Assert.AreEqual(3.0, matrix[1, 1]);
+            Assert.AreEqual(0.0, matrix[1, 2]);
+            Assert.AreEqual(4.0, matrix[2, 0]);
+            Assert.AreEqual(0.0, matrix[2, 1]);
+            Assert.AreEqual(6.0, matrix[2, 2]);
+        }
+
+        /// <summary>
+        /// Can parse underscore delimited sparse data.
+        /// </summary>
+        [Test]
+        public void CanParseUnderscoreDelimitedData()
+        {
+            var data = "a_b_c" + Environment.NewLine
+                       + "1" + Environment.NewLine
+                       + "\"2.2\"_.3e1" + Environment.NewLine
+                       + "'4'_0_6" + Environment.NewLine;
+
+            var matrix = DelimitedReader.Read<double>(new StringReader(data), false, "_", true, CultureInfo.InvariantCulture, missingValue:0.0f);
             Assert.AreEqual(3, matrix.RowCount);
             Assert.AreEqual(3, matrix.ColumnCount);
             Assert.AreEqual(1.0, matrix[0, 0]);

--- a/src/DataUnitTests/Text/DelimitedWriterTests.cs
+++ b/src/DataUnitTests/Text/DelimitedWriterTests.cs
@@ -151,5 +151,42 @@ namespace MathNet.Numerics.Data.UnitTests.Text
                            + "0 0 9.9";
             Assert.AreEqual(expected, text);
         }
+
+        /// <summary>
+        /// Can write comma delimited data with missing values.
+        /// </summary>
+        [Test]
+        public void CanWriteCommaDelimitedDataWithMissingValues()
+        {
+            var matrix = SparseMatrix.OfArray(new[,] { { 1.1, 0, 0 }, { 0, 5.5, 0 }, { 0, 0, 9.9 } });
+            var stream = new MemoryStream();
+            DelimitedWriter.Write(stream, matrix, ",", missingValue: 0);
+            var data = stream.ToArray();
+            var reader = new StreamReader(new MemoryStream(data));
+            var text = reader.ReadToEnd();
+            var expected = @"1.1,," + Environment.NewLine
+                           + ",5.5," + Environment.NewLine
+                           + ",,9.9";
+            Assert.AreEqual(expected, text);
+        }
+
+
+        /// <summary>
+        /// Can write space delimited data with missing values.
+        /// </summary>
+        [Test]
+        public void CanWriteTabDelimitedDataWithMissingValues()
+        {
+            var matrix = DenseMatrix.OfArray(new[,] { { 1.1, Double.NaN, 0 }, { 0, 5.5, 0 }, { Double.NaN, Double.NaN, 9.9 } });
+            var stream = new MemoryStream();
+            DelimitedWriter.Write(stream, matrix, "\t", missingValue: Double.NaN);
+            var data = stream.ToArray();
+            var reader = new StreamReader(new MemoryStream(data));
+            var text = reader.ReadToEnd();
+            var expected = "1.1\t\t0" + Environment.NewLine
+                           + "0\t5.5\t0" + Environment.NewLine
+                           + "\t\t9.9";
+            Assert.AreEqual(expected, text);
+        }
     }
 }


### PR DESCRIPTION
The reader on average should be about 15% slower. There should be no performance difference on the writer 