### PR TITLE
Native provider loader fixes

### DIFF
--- a/MathNet.Numerics.NativeProviders.sln
+++ b/MathNet.Numerics.NativeProviders.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30501.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Common", "Common", "{5A0892FF-82CE-40FC-BCE1-73810C615F52}"
 	ProjectSection(SolutionItems) = preProject
@@ -97,18 +97,14 @@ Global
 		{3515A344-AB5F-41C7-A14C-04A79B3FFAB1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3515A344-AB5F-41C7-A14C-04A79B3FFAB1}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
 		{3515A344-AB5F-41C7-A14C-04A79B3FFAB1}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{3515A344-AB5F-41C7-A14C-04A79B3FFAB1}.Debug|Win32.ActiveCfg = Debug|x86
-		{3515A344-AB5F-41C7-A14C-04A79B3FFAB1}.Debug|Win32.Build.0 = Debug|x86
-		{3515A344-AB5F-41C7-A14C-04A79B3FFAB1}.Debug|x64.ActiveCfg = Debug|x64
-		{3515A344-AB5F-41C7-A14C-04A79B3FFAB1}.Debug|x64.Build.0 = Debug|x64
+		{3515A344-AB5F-41C7-A14C-04A79B3FFAB1}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{3515A344-AB5F-41C7-A14C-04A79B3FFAB1}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{3515A344-AB5F-41C7-A14C-04A79B3FFAB1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3515A344-AB5F-41C7-A14C-04A79B3FFAB1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3515A344-AB5F-41C7-A14C-04A79B3FFAB1}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{3515A344-AB5F-41C7-A14C-04A79B3FFAB1}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{3515A344-AB5F-41C7-A14C-04A79B3FFAB1}.Release|Win32.ActiveCfg = Release|x86
-		{3515A344-AB5F-41C7-A14C-04A79B3FFAB1}.Release|Win32.Build.0 = Release|x86
-		{3515A344-AB5F-41C7-A14C-04A79B3FFAB1}.Release|x64.ActiveCfg = Release|x64
-		{3515A344-AB5F-41C7-A14C-04A79B3FFAB1}.Release|x64.Build.0 = Release|x64
+		{3515A344-AB5F-41C7-A14C-04A79B3FFAB1}.Release|Win32.ActiveCfg = Release|Any CPU
+		{3515A344-AB5F-41C7-A14C-04A79B3FFAB1}.Release|x64.ActiveCfg = Release|Any CPU
 		{3515A344-AB5F-41C7-A14C-04A79B3FFAB1}.Release-Signed|Any CPU.ActiveCfg = Release|Any CPU
 		{3515A344-AB5F-41C7-A14C-04A79B3FFAB1}.Release-Signed|Any CPU.Build.0 = Release|Any CPU
 		{3515A344-AB5F-41C7-A14C-04A79B3FFAB1}.Release-Signed|Mixed Platforms.ActiveCfg = Release|Any CPU

--- a/src/Numerics/Providers/NativeProviderLoader.cs
+++ b/src/Numerics/Providers/NativeProviderLoader.cs
@@ -49,7 +49,7 @@ namespace MathNet.Numerics.Providers
                                 () => new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
                                 {
                                     {"x86", "x86"},
-                                    {"AMD64", "amd64"},
+                                    {"AMD64", "x64"},
                                     {"IA64", "ia64"},
                                     {"ARM", "arm"}
                                 },

--- a/src/UnitTests/UnitTests-MKL.csproj
+++ b/src/UnitTests/UnitTests-MKL.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DefineConstants>TRACE;NATIVE</DefineConstants>
-    <OutputPath>..\..\out\MKL\Windows\AnyCPU\</OutputPath>
+    <OutputPath>..\..\out\MKL\Windows\</OutputPath>
     <IntermediateOutputPath>..\..\obj\MKL\Windows\x86\</IntermediateOutputPath>
     <BaseIntermediateOutputPath>..\..\obj\MKL\Windows\x86\</BaseIntermediateOutputPath>
     <Optimize>true</Optimize>
@@ -29,7 +29,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DefineConstants>TRACE;DEBUG;NATIVE</DefineConstants>
-    <OutputPath>..\..\out\MKL\Windows\AnyCPU\</OutputPath>
+    <OutputPath>..\..\out\MKL\Windows\</OutputPath>
     <IntermediateOutputPath>..\..\obj\MKL\Windows\x86\</IntermediateOutputPath>
     <BaseIntermediateOutputPath>..\..\obj\MKL\Windows\x86\</BaseIntermediateOutputPath>
     <Optimize>false</Optimize>
@@ -39,54 +39,6 @@
     <WarningLevel>4</WarningLevel>
     <NoWarn>1591</NoWarn>
     <PlatformTarget>AnyCPU</PlatformTarget>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <OutputPath>..\..\out\MKL\Windows\x86\</OutputPath>
-    <IntermediateOutputPath>..\..\obj\MKL\Windows\x86\</IntermediateOutputPath>
-    <BaseIntermediateOutputPath>..\..\obj\MKL\Windows\x86\</BaseIntermediateOutputPath>
-    <DefineConstants>TRACE;NATIVE</DefineConstants>
-    <Optimize>true</Optimize>
-    <NoWarn>1591</NoWarn>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>..\..\out\MKL\Windows\x86\</OutputPath>
-    <IntermediateOutputPath>..\..\obj\MKL\Windows\x86\</IntermediateOutputPath>
-    <BaseIntermediateOutputPath>..\..\obj\MKL\Windows\x86\</BaseIntermediateOutputPath>
-    <DefineConstants>TRACE;DEBUG;NATIVE</DefineConstants>
-    <NoWarn>1591</NoWarn>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-    <OutputPath>..\..\out\MKL\Windows\x64\</OutputPath>
-    <IntermediateOutputPath>..\..\obj\MKL\Windows\x64\</IntermediateOutputPath>
-    <BaseIntermediateOutputPath>..\..\obj\MKL\Windows\x64\</BaseIntermediateOutputPath>
-    <DefineConstants>TRACE;NATIVE</DefineConstants>
-    <Optimize>true</Optimize>
-    <NoWarn>1591</NoWarn>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>..\..\out\MKL\Windows\x64\</OutputPath>
-    <IntermediateOutputPath>..\..\obj\MKL\Windows\x64\</IntermediateOutputPath>
-    <BaseIntermediateOutputPath>..\..\obj\MKL\Windows\x64\</BaseIntermediateOutputPath>
-    <DefineConstants>TRACE;DEBUG;NATIVE</DefineConstants>
-    <NoWarn>1591</NoWarn>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
Couple of fixes to problems I found with the `NativeProviderLoader`.
* Couldn't find / load library dependencies in the architecture directory -> changed to `LoadLibraryEx`
* MSTest / Xunit would fail to locate the native library due to copying assemblies to Temp -> look in `AppDomain.Current.BaseDirectory` as well as `Assembly.GetExecutingAssembly().Location`.