### PR TITLE
Change Nuget targets to use 'Content' rather than 'Copy' and 'Delete'

### DIFF
--- a/build/MathNet.Numerics.CUDA.Win.targets
+++ b/build/MathNet.Numerics.CUDA.Win.targets
@@ -8,67 +8,20 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--
   ******************************************************************************
-  **                    MathNet Interop Library Build Items                   **
+  **                    MathNet Interop Library Files                         **
   ******************************************************************************
   -->
 
-  <ItemGroup>
-    <MathNetInteropFiles Condition="'$(MSBuildThisFileDirectory)' != '' And
-                                   HasTrailingSlash('$(MSBuildThisFileDirectory)')"
-                        Include="$(MSBuildThisFileDirectory)**\*.dll" />
-  </ItemGroup>
-
-  <!--
-  ******************************************************************************
-  **                   MathNet Interop Library Build Targets                  **
-  ******************************************************************************
-  -->
-
-  <Target Name="CopyMathNetInteropFiles"
-          Condition="'$(CopyMathNetInteropFiles)' != 'false' And
-                     '$(OutputPath)' != '' And
-                     HasTrailingSlash('$(OutputPath)') And
-                     Exists('$(OutputPath)')"
-          Inputs="@(MathNetInteropFiles)"
-          Outputs="@(MathNetInteropFiles -> '$(OutputPath)%(RecursiveDir)%(Filename)%(Extension)')">
+  <ItemGroup Condition="'$(MSBuildThisFileDirectory)' != '' And
+                         HasTrailingSlash('$(MSBuildThisFileDirectory)')">
     <!--
         NOTE: Copy "MathNet.Numerics.CUDA.dll" and all related files, for every
               architecture that we support, to the build output directory.
     -->
-    <Copy SourceFiles="@(MathNetInteropFiles)"
-          DestinationFiles="@(MathNetInteropFiles -> '$(OutputPath)%(RecursiveDir)%(Filename)%(Extension)')" />
-  </Target>
-
-  <!--
-  ******************************************************************************
-  -->
-
-  <Target Name="CleanMathNetInteropFiles"
-          Condition="'$(CleanMathNetInteropFiles)' != 'false' And
-                     '$(OutputPath)' != '' And
-                     HasTrailingSlash('$(OutputPath)') And
-                     Exists('$(OutputPath)')">
-    <!--
-        NOTE: Delete "MathNet.Numerics.CUDA.dll" and all related files, for every
-              architecture that we support, from the build output directory.
-    -->
-    <Delete Files="@(MathNetInteropFiles -> '$(OutputPath)%(RecursiveDir)%(Filename)%(Extension)')" />
-  </Target>
-
-  <!--
-  ******************************************************************************
-  **                 MathNet Interop Library Build Properties                 **
-  ******************************************************************************
-  -->
-
-  <PropertyGroup>
-    <BuildDependsOn>
-      $(BuildDependsOn);
-      CopyMathNetInteropFiles;
-    </BuildDependsOn>
-    <CleanDependsOn>
-      $(CleanDependsOn);
-      CleanMathNetInteropFiles;
-    </CleanDependsOn>
-  </PropertyGroup>
+    <MathNetInteropFiles Include="$(MSBuildThisFileDirectory)**\*.dll" />
+    <Content Include="@(MathNetInteropFiles)">
+      <Link>%(RecursiveDir)%(FileName)%(Extension)</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/build/MathNet.Numerics.MKL.Win.targets
+++ b/build/MathNet.Numerics.MKL.Win.targets
@@ -8,67 +8,20 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--
   ******************************************************************************
-  **                    MathNet Interop Library Build Items                   **
+  **                    MathNet Interop Library Files                         **
   ******************************************************************************
   -->
 
-  <ItemGroup>
-    <MathNetInteropFiles Condition="'$(MSBuildThisFileDirectory)' != '' And
-                                   HasTrailingSlash('$(MSBuildThisFileDirectory)')"
-                        Include="$(MSBuildThisFileDirectory)**\*.dll" />
-  </ItemGroup>
-
-  <!--
-  ******************************************************************************
-  **                   MathNet Interop Library Build Targets                  **
-  ******************************************************************************
-  -->
-
-  <Target Name="CopyMathNetInteropFiles"
-          Condition="'$(CopyMathNetInteropFiles)' != 'false' And
-                     '$(OutputPath)' != '' And
-                     HasTrailingSlash('$(OutputPath)') And
-                     Exists('$(OutputPath)')"
-          Inputs="@(MathNetInteropFiles)"
-          Outputs="@(MathNetInteropFiles -> '$(OutputPath)%(RecursiveDir)%(Filename)%(Extension)')">
+  <ItemGroup Condition="'$(MSBuildThisFileDirectory)' != '' And
+                         HasTrailingSlash('$(MSBuildThisFileDirectory)')">
     <!--
         NOTE: Copy "MathNet.Numerics.MKL.dll" and all related files, for every
               architecture that we support, to the build output directory.
     -->
-    <Copy SourceFiles="@(MathNetInteropFiles)"
-          DestinationFiles="@(MathNetInteropFiles -> '$(OutputPath)%(RecursiveDir)%(Filename)%(Extension)')" />
-  </Target>
-
-  <!--
-  ******************************************************************************
-  -->
-
-  <Target Name="CleanMathNetInteropFiles"
-          Condition="'$(CleanMathNetInteropFiles)' != 'false' And
-                     '$(OutputPath)' != '' And
-                     HasTrailingSlash('$(OutputPath)') And
-                     Exists('$(OutputPath)')">
-    <!--
-        NOTE: Delete "MathNet.Numerics.MKL.dll" and all related files, for every
-              architecture that we support, from the build output directory.
-    -->
-    <Delete Files="@(MathNetInteropFiles -> '$(OutputPath)%(RecursiveDir)%(Filename)%(Extension)')" />
-  </Target>
-
-  <!--
-  ******************************************************************************
-  **                 MathNet Interop Library Build Properties                 **
-  ******************************************************************************
-  -->
-
-  <PropertyGroup>
-    <BuildDependsOn>
-      $(BuildDependsOn);
-      CopyMathNetInteropFiles;
-    </BuildDependsOn>
-    <CleanDependsOn>
-      $(CleanDependsOn);
-      CleanMathNetInteropFiles;
-    </CleanDependsOn>
-  </PropertyGroup>
+    <MathNetInteropFiles Include="$(MSBuildThisFileDirectory)**\*.dll" />
+    <Content Include="@(MathNetInteropFiles)">
+      <Link>%(RecursiveDir)%(FileName)%(Extension)</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/build/MathNet.Numerics.OpenBLAS.Win.targets
+++ b/build/MathNet.Numerics.OpenBLAS.Win.targets
@@ -8,67 +8,20 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--
   ******************************************************************************
-  **                    MathNet Interop Library Build Items                   **
+  **                    MathNet Interop Library Files                         **
   ******************************************************************************
   -->
 
-  <ItemGroup>
-    <MathNetInteropFiles Condition="'$(MSBuildThisFileDirectory)' != '' And
-                                   HasTrailingSlash('$(MSBuildThisFileDirectory)')"
-                        Include="$(MSBuildThisFileDirectory)**\*.dll" />
-  </ItemGroup>
-
-  <!--
-  ******************************************************************************
-  **                   MathNet Interop Library Build Targets                  **
-  ******************************************************************************
-  -->
-
-  <Target Name="CopyMathNetInteropFiles"
-          Condition="'$(CopyMathNetInteropFiles)' != 'false' And
-                     '$(OutputPath)' != '' And
-                     HasTrailingSlash('$(OutputPath)') And
-                     Exists('$(OutputPath)')"
-          Inputs="@(MathNetInteropFiles)"
-          Outputs="@(MathNetInteropFiles -> '$(OutputPath)%(RecursiveDir)%(Filename)%(Extension)')">
+  <ItemGroup Condition="'$(MSBuildThisFileDirectory)' != '' And
+                         HasTrailingSlash('$(MSBuildThisFileDirectory)')">
     <!--
         NOTE: Copy "MathNet.Numerics.OpenBLAS.dll" and all related files, for every
               architecture that we support, to the build output directory.
     -->
-    <Copy SourceFiles="@(MathNetInteropFiles)"
-          DestinationFiles="@(MathNetInteropFiles -> '$(OutputPath)%(RecursiveDir)%(Filename)%(Extension)')" />
-  </Target>
-
-  <!--
-  ******************************************************************************
-  -->
-
-  <Target Name="CleanMathNetInteropFiles"
-          Condition="'$(CleanMathNetInteropFiles)' != 'false' And
-                     '$(OutputPath)' != '' And
-                     HasTrailingSlash('$(OutputPath)') And
-                     Exists('$(OutputPath)')">
-    <!--
-        NOTE: Delete "MathNet.Numerics.OpenBLAS.dll" and all related files, for every
-              architecture that we support, from the build output directory.
-    -->
-    <Delete Files="@(MathNetInteropFiles -> '$(OutputPath)%(RecursiveDir)%(Filename)%(Extension)')" />
-  </Target>
-
-  <!--
-  ******************************************************************************
-  **                 MathNet Interop Library Build Properties                 **
-  ******************************************************************************
-  -->
-
-  <PropertyGroup>
-    <BuildDependsOn>
-      $(BuildDependsOn);
-      CopyMathNetInteropFiles;
-    </BuildDependsOn>
-    <CleanDependsOn>
-      $(CleanDependsOn);
-      CleanMathNetInteropFiles;
-    </CleanDependsOn>
-  </PropertyGroup>
+    <MathNetInteropFiles Include="$(MSBuildThisFileDirectory)**\*.dll" />
+    <Content Include="@(MathNetInteropFiles)">
+      <Link>%(RecursiveDir)%(FileName)%(Extension)</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
The 'Copy' and 'Delete' tasks will only work for a project which is directly executed (an executable). It won't work for any projects which reference the project which includes one of the MathNet nuget packages (such as a unit test project). Installer projects such as WiX or VS Setup projects similarly won't find the required library files unless they are 'Content'.