### PR TITLE
Add a method to construct a beta PERT distribution

### DIFF
--- a/src/Numerics/Distributions/Beta.cs
+++ b/src/Numerics/Distributions/Beta.cs
@@ -92,6 +92,48 @@ namespace MathNet.Numerics.Distributions
             _shapeB = b;
         }
 
+
+        /// <summary>
+        /// Create a Beta PERT distribution, used in risk analysis and other domains where an expert forecast
+        /// is used to construct an underlying beta distribution.
+        /// </summary>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="likely">The most likely value (mode).</param>
+        /// <returns>The Beta distribution derived from the PERT parameters.</returns>
+        public static Beta PERT(double min, double max, double likely)
+        {
+            if( min > max || likely > max || likely < min )
+            {
+                throw new ArgumentException(Resources.InvalidDistributionParameters);
+            }
+
+            // specified to make the formulas match the literature;
+            // traditionally set to 4 so that the range between min and max
+            // represents six standard deviations (sometimes called
+            // "the six-sigma assumption").
+            const double lambda = 4;
+
+            // calculate the mean
+            double mean = (min + max + lambda * likely) / (lambda + 2);
+
+            // derive the shape parameters a and b
+            double a;
+            // special case where mean and mode are identical
+            if (mean == likely)
+            {
+                a = (lambda/2) + 1;
+            }
+            else
+            {
+                a = ((mean - min) * (2 * likely - min - max)) / ((likely - mean) * (max - min))
+            }
+
+            double b = (a * (max - mean)) / (mean - min);
+
+            return new Beta(a, b);
+        }
+
         /// <summary>
         /// A string representation of the distribution.
         /// </summary>

--- a/src/Numerics/Distributions/Beta.cs
+++ b/src/Numerics/Distributions/Beta.cs
@@ -126,7 +126,7 @@ namespace MathNet.Numerics.Distributions
             }
             else
             {
-                a = ((mean - min) * (2 * likely - min - max)) / ((likely - mean) * (max - min))
+                a = ((mean - min) * (2 * likely - min - max)) / ((likely - mean) * (max - min));
             }
 
             double b = (a * (max - mean)) / (mean - min);

--- a/src/Numerics/Distributions/Beta.cs
+++ b/src/Numerics/Distributions/Beta.cs
@@ -100,8 +100,9 @@ namespace MathNet.Numerics.Distributions
         /// <param name="min">The minimum value.</param>
         /// <param name="max">The maximum value.</param>
         /// <param name="likely">The most likely value (mode).</param>
+        /// <param name="randomSource">The random number generator which is used to draw random samples.</param>
         /// <returns>The Beta distribution derived from the PERT parameters.</returns>
-        public static Beta PERT(double min, double max, double likely)
+        public static Beta PERT(double min, double max, double likely, System.Random randomSource = null)
         {
             if( min > max || likely > max || likely < min )
             {
@@ -131,7 +132,7 @@ namespace MathNet.Numerics.Distributions
 
             double b = (a * (max - mean)) / (mean - min);
 
-            return new Beta(a, b);
+            return new Beta(a, b, randomSource);
         }
 
         /// <summary>


### PR DESCRIPTION
A beta PERT derives the shape parameters from the min, max, and mode -- this is often used in risk analysis, disease management, and other domains where an expert forecast or assessment is required.

This PR adds a static PERT method to the Beta class to instantiate a beta distribution from the min, max, and mode parameters. Note that I named the mode parameter "likely" to better match other libraries but would be happy to rename.