### PR TITLE
Added Functional Vector and Matrix Integration

### DIFF
--- a/src/Numerics/Integrate.cs
+++ b/src/Numerics/Integrate.cs
@@ -30,6 +30,7 @@
 
 using System;
 using MathNet.Numerics.Integration;
+using MathNet.Numerics.LinearAlgebra;
 
 namespace MathNet.Numerics
 {

--- a/src/Numerics/Integrate.cs
+++ b/src/Numerics/Integrate.cs
@@ -29,6 +29,7 @@
 // </copyright>
 
 using System;
+using MathNet.Numerics;
 using MathNet.Numerics.Integration;
 using MathNet.Numerics.LinearAlgebra;
 

--- a/src/Numerics/Integrate.cs
+++ b/src/Numerics/Integrate.cs
@@ -62,5 +62,72 @@ namespace MathNet.Numerics
         {
             return DoubleExponentialTransformation.Integrate(f, intervalBegin, intervalEnd, 1e-8);
         }
+        
+         #region Matrix Integration
+         
+        /// <summary>
+        /// Approximation of the definite integral of an analytic smooth function valued matrix on a closed interval.
+        /// </summary>
+        /// <param name="F">The analytic smooth functional matrix to integrate.</param>
+        /// <param name="intervalBegin">Where the interval starts, inclusive and finite.</param>
+        /// <param name="intervalEnd">Where the interval stops, inclusive and finite.</param>
+        /// <param name="targetAbsoluteError">The expected relative accuracy of the approximation.</param>
+        /// <returns>Approximation of the finite integral in the given interval.</returns>
+        public static Matrix<double> OnClosedInterval(
+            Matrix<Func<double, double>> F, double intervalBegin, double intervalEnd, double absoluteTargetError)
+        {
+            return F.Map(
+                f => Integrate.OnClosedInterval(f, intervalBegin, intervalEnd, absoluteTargetError)
+            );
+        }
+
+        /// <summary>
+        /// Approximation of the definite integral of an analytic smooth function valued matrix on a closed interval.
+        /// </summary>
+        /// <param name="F">The analytic smooth functional matrix to integrate.</param>
+        /// <param name="intervalBegin">Where the interval starts, inclusive and finite.</param>
+        /// <param name="intervalEnd">Where the interval stops, inclusive and finite.</param>
+        /// <returns>Approximation of the finite integral in the given interval.</returns>
+        public static Matrix<double> OnClosedInterval(
+            Matrix<Func<double, double>> F, double intervalBegin, double intervalEnd)
+        {
+            return Integrate.OnClosedInterval(F, intervalBegin, intervalEnd, 1e-8);
+        }
+
+        #endregion Matrix Integration
+
+
+        #region Vector Integration
+
+        /// <summary>
+        /// Approximation of the definite integral of an analytic smooth function valued vector on a closed interval.
+        /// </summary>
+        /// <param name="F">The analytic smooth functional vector to integrate.</param>
+        /// <param name="intervalBegin">Where the interval starts, inclusive and finite.</param>
+        /// <param name="intervalEnd">Where the interval stops, inclusive and finite.</param>
+        /// <param name="targetAbsoluteError">The expected relative accuracy of the approximation.</param>
+        /// <returns>Approximation of the finite integral in the given interval.</returns>
+        public static Vector<double> OnClosedInterval(
+            Vector<Func<double, double>> F, double intervalBegin, double intervalEnd, double absoluteTargetError)
+        {
+            return F.Map(
+                f => Integrate.OnClosedInterval(f, intervalBegin, intervalEnd, absoluteTargetError)
+            );
+        }
+
+        /// <summary>
+        /// Approximation of the definite integral of an analytic smooth function valued vector on a closed interval.
+        /// </summary>
+        /// <param name="F">The analytic smooth functional vector to integrate.</param>
+        /// <param name="intervalBegin">Where the interval starts, inclusive and finite.</param>
+        /// <param name="intervalEnd">Where the interval stops, inclusive and finite.</param>
+        /// <returns>Approximation of the finite integral in the given interval.</returns>
+        public static Vector<double> OnClosedInterval(
+            Vector<Func<double, double>> F, double intervalBegin, double intervalEnd)
+        {
+            return Integrate.OnClosedInterval(F, intervalBegin, intervalEnd, 1e-8);
+        }
+
+        #endregion Vector Integration
     }
 }


### PR DESCRIPTION
Created extensions for Vector and Matrix integration in Numerics.Integrate. Should I add these directly to the individual integration methods and thereafter create an extension within Numerics.Integrate?