### PR TITLE
Minor comment corrections

### DIFF
--- a/src/Numerics/Distributions/Bernoulli.cs
+++ b/src/Numerics/Distributions/Bernoulli.cs
@@ -101,7 +101,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the probability of generating a one. Range: 0 ≤ p ≤ 1.
+        /// Gets the probability of generating a one. Range: 0 ≤ p ≤ 1.
         /// </summary>
         public double P
         {

--- a/src/Numerics/Distributions/Beta.cs
+++ b/src/Numerics/Distributions/Beta.cs
@@ -112,7 +112,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the α shape parameter of the Beta distribution. Range: α ≥ 0.
+        /// Gets the α shape parameter of the Beta distribution. Range: α ≥ 0.
         /// </summary>
         public double A
         {
@@ -120,7 +120,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the β shape parameter of the Beta distribution. Range: β ≥ 0.
+        /// Gets the β shape parameter of the Beta distribution. Range: β ≥ 0.
         /// </summary>
         public double B
         {

--- a/src/Numerics/Distributions/BetaScaled.cs
+++ b/src/Numerics/Distributions/BetaScaled.cs
@@ -153,7 +153,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the α shape parameter of the BetaScaled distribution. Range: α > 0.
+        /// Gets the α shape parameter of the BetaScaled distribution. Range: α > 0.
         /// </summary>
         public double A
         {
@@ -161,7 +161,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the β shape parameter of the BetaScaled distribution. Range: β > 0.
+        /// Gets the β shape parameter of the BetaScaled distribution. Range: β > 0.
         /// </summary>
         public double B
         {
@@ -169,7 +169,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the location (μ) of the BetaScaled distribution.
+        /// Gets the location (μ) of the BetaScaled distribution.
         /// </summary>
         public double Location
         {
@@ -177,7 +177,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the scale (σ) of the BetaScaled distribution. Range: σ > 0.
+        /// Gets the scale (σ) of the BetaScaled distribution. Range: σ > 0.
         /// </summary>
         public double Scale
         {

--- a/src/Numerics/Distributions/Binomial.cs
+++ b/src/Numerics/Distributions/Binomial.cs
@@ -110,7 +110,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the success probability in each trial. Range: 0 ≤ p ≤ 1.
+        /// Gets the success probability in each trial. Range: 0 ≤ p ≤ 1.
         /// </summary>
         public double P
         {
@@ -118,7 +118,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the number of trials. Range: n ≥ 0.
+        /// Gets the number of trials. Range: n ≥ 0.
         /// </summary>
         public int N
         {

--- a/src/Numerics/Distributions/Categorical.cs
+++ b/src/Numerics/Distributions/Categorical.cs
@@ -203,7 +203,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the probability mass vector (non-negative ratios) of the multinomial.
+        /// Gets the probability mass vector (non-negative ratios) of the multinomial.
         /// </summary>
         /// <remarks>Sometimes the normalized probability vector cannot be represented exactly in a floating point representation.</remarks>
         public double[] P

--- a/src/Numerics/Distributions/Cauchy.cs
+++ b/src/Numerics/Distributions/Cauchy.cs
@@ -110,7 +110,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the location  (x0) of the distribution.
+        /// Gets the location  (x0) of the distribution.
         /// </summary>
         public double Location
         {
@@ -118,7 +118,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the scale (γ) of the distribution. Range: γ > 0.
+        /// Gets the scale (γ) of the distribution. Range: γ > 0.
         /// </summary>
         public double Scale
         {

--- a/src/Numerics/Distributions/Chi.cs
+++ b/src/Numerics/Distributions/Chi.cs
@@ -99,7 +99,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the degrees of freedom (k) of the Chi distribution. Range: k > 0.
+        /// Gets the degrees of freedom (k) of the Chi distribution. Range: k > 0.
         /// </summary>
         public double DegreesOfFreedom
         {

--- a/src/Numerics/Distributions/ChiSquared.cs
+++ b/src/Numerics/Distributions/ChiSquared.cs
@@ -97,7 +97,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the degrees of freedom (k) of the Chi-Squared distribution. Range: k > 0.
+        /// Gets the degrees of freedom (k) of the Chi-Squared distribution. Range: k > 0.
         /// </summary>
         public double DegreesOfFreedom
         {

--- a/src/Numerics/Distributions/ContinuousUniform.cs
+++ b/src/Numerics/Distributions/ContinuousUniform.cs
@@ -112,7 +112,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the lower bound of the distribution.
+        /// Gets the lower bound of the distribution.
         /// </summary>
         public double LowerBound
         {
@@ -120,7 +120,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the upper bound of the distribution.
+        /// Gets the upper bound of the distribution.
         /// </summary>
         public double UpperBound
         {

--- a/src/Numerics/Distributions/ConwayMaxwellPoisson.cs
+++ b/src/Numerics/Distributions/ConwayMaxwellPoisson.cs
@@ -131,7 +131,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the lambda (λ) parameter. Range: λ > 0.
+        /// Gets the lambda (λ) parameter. Range: λ > 0.
         /// </summary>
         public double Lambda
         {
@@ -139,7 +139,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the rate of decay (ν) parameter. Range: ν ≥ 0.
+        /// Gets the rate of decay (ν) parameter. Range: ν ≥ 0.
         /// </summary>
         public double Nu
         {

--- a/src/Numerics/Distributions/Erlang.cs
+++ b/src/Numerics/Distributions/Erlang.cs
@@ -133,7 +133,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the shape (k) of the Erlang distribution. Range: k ≥ 0.
+        /// Gets the shape (k) of the Erlang distribution. Range: k ≥ 0.
         /// </summary>
         public int Shape
         {
@@ -141,7 +141,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the rate or inverse scale (λ) of the Erlang distribution. Range: λ ≥ 0.
+        /// Gets the rate or inverse scale (λ) of the Erlang distribution. Range: λ ≥ 0.
         /// </summary>
         public double Rate
         {
@@ -149,7 +149,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the scale of the Erlang distribution.
+        /// Gets the scale of the Erlang distribution.
         /// </summary>
         public double Scale
         {

--- a/src/Numerics/Distributions/Exponential.cs
+++ b/src/Numerics/Distributions/Exponential.cs
@@ -98,7 +98,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the rate (λ) parameter of the distribution. Range: λ ≥ 0.
+        /// Gets the rate (λ) parameter of the distribution. Range: λ ≥ 0.
         /// </summary>
         public double Rate
         {

--- a/src/Numerics/Distributions/FisherSnedecor.cs
+++ b/src/Numerics/Distributions/FisherSnedecor.cs
@@ -104,7 +104,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the first degree of freedom (d1) of the distribution. Range: d1 > 0.
+        /// Gets the first degree of freedom (d1) of the distribution. Range: d1 > 0.
         /// </summary>
         public double DegreesOfFreedom1
         {
@@ -112,7 +112,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the second degree of freedom (d2) of the distribution. Range: d2 > 0.
+        /// Gets the second degree of freedom (d2) of the distribution. Range: d2 > 0.
         /// </summary>
         public double DegreesOfFreedom2
         {

--- a/src/Numerics/Distributions/Geometric.cs
+++ b/src/Numerics/Distributions/Geometric.cs
@@ -99,7 +99,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the probability of generating a one. Range: 0 ≤ p ≤ 1.
+        /// Gets the probability of generating a one. Range: 0 ≤ p ≤ 1.
         /// </summary>
         public double P
         {

--- a/src/Numerics/Distributions/Hypergeometric.cs
+++ b/src/Numerics/Distributions/Hypergeometric.cs
@@ -121,7 +121,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the size of the population (N).
+        /// Gets the size of the population (N).
         /// </summary>
         public int Population
         {
@@ -129,7 +129,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the number of draws without replacement (n).
+        /// Gets the number of draws without replacement (n).
         /// </summary>
         public int Draws
         {
@@ -137,7 +137,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the number successes within the population (K, M).
+        /// Gets the number successes within the population (K, M).
         /// </summary>
         public int Success
         {

--- a/src/Numerics/Distributions/Laplace.cs
+++ b/src/Numerics/Distributions/Laplace.cs
@@ -115,7 +115,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the location (μ) of the Laplace distribution.
+        /// Gets the location (μ) of the Laplace distribution.
         /// </summary>
         public double Location
         {
@@ -123,7 +123,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the scale (b) of the Laplace distribution. Range: b > 0.
+        /// Gets the scale (b) of the Laplace distribution. Range: b > 0.
         /// </summary>
         public double Scale
         {

--- a/src/Numerics/Distributions/LogNormal.cs
+++ b/src/Numerics/Distributions/LogNormal.cs
@@ -147,7 +147,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the log-scale (μ) (mean of the logarithm) of the distribution.
+        /// Gets the log-scale (μ) (mean of the logarithm) of the distribution.
         /// </summary>
         public double Mu
         {
@@ -155,7 +155,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the shape (σ) (standard deviation of the logarithm) of the distribution. Range: σ ≥ 0.
+        /// Gets the shape (σ) (standard deviation of the logarithm) of the distribution. Range: σ ≥ 0.
         /// </summary>
         public double Sigma
         {

--- a/src/Numerics/Distributions/MatrixNormal.cs
+++ b/src/Numerics/Distributions/MatrixNormal.cs
@@ -153,7 +153,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the mean. (M)
+        /// Gets the mean. (M)
         /// </summary>
         /// <value>The mean of the distribution.</value>
         public Matrix<double> Mean
@@ -162,7 +162,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the row covariance. (V)
+        /// Gets the row covariance. (V)
         /// </summary>
         /// <value>The row covariance.</value>
         public Matrix<double> RowCovariance
@@ -171,7 +171,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the column covariance. (K)
+        /// Gets the column covariance. (K)
         /// </summary>
         /// <value>The column covariance.</value>
         public Matrix<double> ColumnCovariance

--- a/src/Numerics/Distributions/Multinomial.cs
+++ b/src/Numerics/Distributions/Multinomial.cs
@@ -176,7 +176,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the proportion of ratios.
+        /// Gets the proportion of ratios.
         /// </summary>
         public double[] P
         {
@@ -184,7 +184,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the number of trials.
+        /// Gets the number of trials.
         /// </summary>
         public int N
         {

--- a/src/Numerics/Distributions/NegativeBinomial.cs
+++ b/src/Numerics/Distributions/NegativeBinomial.cs
@@ -106,7 +106,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the number of trials. Range: r ≥ 0.
+        /// Gets the number of trials. Range: r ≥ 0.
         /// </summary>
         public double R
         {
@@ -114,7 +114,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the probability of success. Range: 0 ≤ p ≤ 1.
+        /// Gets the probability of success. Range: 0 ≤ p ≤ 1.
         /// </summary>
         public double P
         {

--- a/src/Numerics/Distributions/Normal.cs
+++ b/src/Numerics/Distributions/Normal.cs
@@ -175,7 +175,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the mean (μ) of the normal distribution.
+        /// Gets the mean (μ) of the normal distribution.
         /// </summary>
         public double Mean
         {
@@ -183,7 +183,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the standard deviation (σ) of the normal distribution. Range: σ ≥ 0.
+        /// Gets the standard deviation (σ) of the normal distribution. Range: σ ≥ 0.
         /// </summary>
         public double StdDev
         {
@@ -191,7 +191,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the variance of the normal distribution.
+        /// Gets the variance of the normal distribution.
         /// </summary>
         public double Variance
         {
@@ -199,7 +199,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the precision of the normal distribution.
+        /// Gets the precision of the normal distribution.
         /// </summary>
         public double Precision
         {
@@ -207,7 +207,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the random number generator which is used to draw random samples.
+        /// Gets the random number generator which is used to draw random samples.
         /// </summary>
         public System.Random RandomSource
         {

--- a/src/Numerics/Distributions/NormalGamma.cs
+++ b/src/Numerics/Distributions/NormalGamma.cs
@@ -169,7 +169,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the location of the mean.
+        /// Gets the location of the mean.
         /// </summary>
         public double MeanLocation
         {
@@ -177,7 +177,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the scale of the mean.
+        /// Gets the scale of the mean.
         /// </summary>
         public double MeanScale
         {
@@ -185,7 +185,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the shape of the precision.
+        /// Gets the shape of the precision.
         /// </summary>
         public double PrecisionShape
         {
@@ -193,7 +193,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the inverse scale of the precision.
+        /// Gets the inverse scale of the precision.
         /// </summary>
         public double PrecisionInverseScale
         {

--- a/src/Numerics/Distributions/Pareto.cs
+++ b/src/Numerics/Distributions/Pareto.cs
@@ -108,7 +108,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the scale (xm) of the distribution. Range: xm > 0.
+        /// Gets the scale (xm) of the distribution. Range: xm > 0.
         /// </summary>
         public double Scale
         {
@@ -116,7 +116,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the shape (α) of the distribution. Range: α > 0.
+        /// Gets the shape (α) of the distribution. Range: α > 0.
         /// </summary>
         public double Shape
         {

--- a/src/Numerics/Distributions/Poisson.cs
+++ b/src/Numerics/Distributions/Poisson.cs
@@ -103,7 +103,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the Poisson distribution parameter λ. Range: λ > 0.
+        /// Gets the Poisson distribution parameter λ. Range: λ > 0.
         /// </summary>
         public double Lambda
         {
@@ -111,7 +111,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the random number generator which is used to draw random samples.
+        /// Gets the random number generator which is used to draw random samples.
         /// </summary>
         public System.Random RandomSource
         {

--- a/src/Numerics/Distributions/Rayleigh.cs
+++ b/src/Numerics/Distributions/Rayleigh.cs
@@ -103,7 +103,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the scale (σ) of the distribution. Range: σ > 0.
+        /// Gets the scale (σ) of the distribution. Range: σ > 0.
         /// </summary>
         public double Scale
         {

--- a/src/Numerics/Distributions/Stable.cs
+++ b/src/Numerics/Distributions/Stable.cs
@@ -117,7 +117,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the stability (α) of the distribution. Range: 2 ≥ α > 0.
+        /// Gets the stability (α) of the distribution. Range: 2 ≥ α > 0.
         /// </summary>
         public double Alpha
         {
@@ -125,7 +125,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets The skewness (β) of the distribution. Range: 1 ≥ β ≥ -1.
+        /// Gets The skewness (β) of the distribution. Range: 1 ≥ β ≥ -1.
         /// </summary>
         public double Beta
         {
@@ -133,7 +133,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the scale (c) of the distribution. Range: c > 0.
+        /// Gets the scale (c) of the distribution. Range: c > 0.
         /// </summary>
         public double Scale
         {
@@ -141,7 +141,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the location (μ) of the distribution.
+        /// Gets the location (μ) of the distribution.
         /// </summary>
         public double Location
         {

--- a/src/Numerics/Distributions/StudentT.cs
+++ b/src/Numerics/Distributions/StudentT.cs
@@ -139,7 +139,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the location (μ) of the Student t-distribution.
+        /// Gets the location (μ) of the Student t-distribution.
         /// </summary>
         public double Location
         {
@@ -147,7 +147,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the scale (σ) of the Student t-distribution. Range: σ > 0.
+        /// Gets the scale (σ) of the Student t-distribution. Range: σ > 0.
         /// </summary>
         public double Scale
         {
@@ -155,7 +155,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the degrees of freedom (ν) of the Student t-distribution. Range: ν > 0.
+        /// Gets the degrees of freedom (ν) of the Student t-distribution. Range: ν > 0.
         /// </summary>
         public double DegreesOfFreedom
         {

--- a/src/Numerics/Distributions/Triangular.cs
+++ b/src/Numerics/Distributions/Triangular.cs
@@ -115,7 +115,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the lower bound of the distribution.
+        /// Gets the lower bound of the distribution.
         /// </summary>
         public double LowerBound
         {
@@ -123,7 +123,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the upper bound of the distribution.
+        /// Gets the upper bound of the distribution.
         /// </summary>
         public double UpperBound
         {

--- a/src/Numerics/Distributions/Weibull.cs
+++ b/src/Numerics/Distributions/Weibull.cs
@@ -118,7 +118,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the shape (k) of the Weibull distribution. Range: k > 0.
+        /// Gets the shape (k) of the Weibull distribution. Range: k > 0.
         /// </summary>
         public double Shape
         {
@@ -126,7 +126,7 @@ namespace MathNet.Numerics.Distributions
         }
 
         /// <summary>
-        /// Gets or sets the scale (λ) of the Weibull distribution. Range: λ > 0.
+        /// Gets the scale (λ) of the Weibull distribution. Range: λ > 0.
         /// </summary>
         public double Scale
         {

--- a/src/Numerics/Statistics/ArrayStatistics.cs
+++ b/src/Numerics/Statistics/ArrayStatistics.cs
@@ -94,7 +94,7 @@ namespace MathNet.Numerics.Statistics
         }
 
         /// <summary>
-        /// Returns the smallest value from the unsorted data array.
+        /// Returns the largest value from the unsorted data array.
         /// Returns NaN if data is empty or any entry is NaN.
         /// </summary>
         /// <param name="data">Sample array, no sorting is assumed.</param>


### PR DESCRIPTION
I noticed (while adding a truncated normal distribution) that a bunch of comments where slightly wrong. I don't think anyone would have been confused by them but fixed them anyway.

Comments on some properties on most Distributions incorrectly stated
that they were setters as well.
One comment on an array statistic stated it was returned the smallest
instead of largest member.