### PR TITLE
Update mkl native provider for OSX

### DIFF
--- a/docs/content/MKL.md
+++ b/docs/content/MKL.md
@@ -103,6 +103,22 @@ or just copy them e.g. to `/usr/lib`.
 
 For details see Mono's [Interop with Native Libraries](http://www.mono-project.com/docs/advanced/pinvoke/#mac-os-x-framework-and-dylib-search-path).
 
+To build the MKL native provider :
+- make sure you've a valid [Intel MKL](https://software.intel.com/en-us/qualify-for-free-software/academicresearcher) licence installed on your mac (look at opt/intel)
+- open the terminal
+- cd to the folder mathnet-numerics/src/NativeProviders/OSX
+- run the .sh script by typping sh mkl_build.sh
+- ... wait for the build
+- check the mathnet-numerics/out/MKL /x86 and /x64 folders : you should see the li
+
+	[lang=sh]
+	lionel:~ Lionel$ cd /Users/Lionel/Public/Git/GitHub/mathnet-numerics/src/NativeProviders/OSX
+	lionel:OSX Lionel$ ls
+	mkl_build.sh
+	lionel:OSX Lionel$ sh mkl_build.sh
+
+
+
 
 F# Interactive
 --------------

--- a/docs/content/MKL.md
+++ b/docs/content/MKL.md
@@ -104,12 +104,11 @@ or just copy them e.g. to `/usr/lib`.
 For details see Mono's [Interop with Native Libraries](http://www.mono-project.com/docs/advanced/pinvoke/#mac-os-x-framework-and-dylib-search-path).
 
 To build the MKL native provider :
-- make sure you've a valid [Intel MKL](https://software.intel.com/en-us/qualify-for-free-software/academicresearcher) licence installed on your mac (look at opt/intel)
-- open the terminal
-- cd to the folder mathnet-numerics/src/NativeProviders/OSX
-- run the .sh script by typping sh mkl_build.sh
-- ... wait for the build
-- check the mathnet-numerics/out/MKL /x86 and /x64 folders : you should see the li
+1. Make sure you've a valid [intel MKL](https://software.intel.com/en-us/qualify-for-free-software/academicresearcher) licence installed on your mac (look at opt/intel). If not, you can get a free trial on intel's web site.
+1. Open the terminal
+2. cd to the folder mathnet-numerics/src/NativeProviders/OSX
+3. Run the .sh script by typping sh mkl_build.sh
+4. ... wait for the build
 
 	[lang=sh]
 	lionel:~ Lionel$ cd /Users/Lionel/Public/Git/GitHub/mathnet-numerics/src/NativeProviders/OSX
@@ -117,7 +116,17 @@ To build the MKL native provider :
 	mkl_build.sh
 	lionel:OSX Lionel$ sh mkl_build.sh
 
+5. Check the /x86 and /x64 folders in mathnet-numerics/out/MKL : you should now find the libiomp5.dylib and MathNet.Numerics.MKL.dll libaries.
 
+6. you need to add the path to the generated libraies in your `DYLD_LIBRARY_PATH` environnement variable (which you can move to the folder of you choice before). To do that, open your /Users/Lionel/.bas_profile.sh file with a text editor and add the following statements :
+
+	[lang=sh]
+	export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/Users/Lionel/../mathnet-numerics/out/MKL/OSX/x64
+	export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/Users/Lionel/../mathnet-numerics/out/MKL/OSX/x86
+
+Of course replace `Lionel` by your account login.
+
+Have a look a the example down this page to compare MKL-provider vs. managed-provider performances.
 
 
 F# Interactive

--- a/docs/content/MKL.md
+++ b/docs/content/MKL.md
@@ -116,9 +116,9 @@ To build the MKL native provider :
 	mkl_build.sh
 	lionel:OSX Lionel$ sh mkl_build.sh
 
-5. Check the /x86 and /x64 folders in mathnet-numerics/out/MKL : you should now find the libiomp5.dylib and MathNet.Numerics.MKL.dll libaries.
+5. Check the /x86 and /x64 folders in mathnet-numerics/out/MKL : you should now find the `libiomp5.dylib` and `MathNet.Numerics.MKL.dll` libaries.
 
-6. you need to add the path to the generated libraies in your `DYLD_LIBRARY_PATH` environnement variable (which you can move to the folder of you choice before). To do that, open your /Users/Lionel/.bas_profile.sh file with a text editor and add the following statements :
+6. you need to add the path to the generated libraies in your `DYLD_LIBRARY_PATH` environnement variable (which you can move to the folder of you choice before). To do that, open your /Users/Lionel/.bas_profile.sh file with a text editor and add the following statements.
 
 	[lang=sh]
 	export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/Users/Lionel/../mathnet-numerics/out/MKL/OSX/x64

--- a/src/NativeProviders/OSX/mkl_build.sh
+++ b/src/NativeProviders/OSX/mkl_build.sh
@@ -1,15 +1,15 @@
 export INTEL=/opt/intel
 export MKL=$INTEL/mkl
-export OPENMP=$INTEL/composerxe/lib
+export OPENMP=$INTEL/lib
 export OUT=../../../out/MKL/OSX
 
 mkdir -p $OUT/x64
 mkdir -p $OUT/x86
 
-clang++ -D_M_X64 -DGCC -m64 --shared -fPIC -o $OUT/x64/MathNet.Numerics.MKL.dll -I$MKL/include -I../Common ../MKL/memory.c ../MKL/capabilities.cpp ../MKL/vector_functions.c ../MKL/blas.c ../MKL/lapack.cpp $MKL/lib/libmkl_intel_lp64.a $MKL/lib/libmkl_core.a $MKL/lib/libmkl_intel_thread.a -L$OPENMP -liomp5 -lpthread -lm  
+clang++ -std=c++11 -D_M_X64 -DGCC -m64 --shared -fPIC -o $OUT/x64/MathNet.Numerics.MKL.dll -I$MKL/include -I../Common -I../MKL ../MKL/memory.c ../MKL/capabilities.cpp ../MKL/vector_functions.c ../Common/blas.c ../Common/lapack.cpp $MKL/lib/libmkl_intel_lp64.a $MKL/lib/libmkl_core.a $MKL/lib/libmkl_intel_thread.a -L$OPENMP -liomp5 -lpthread -lm
 
 cp $OPENMP/libiomp5.dylib  $OUT/x64/
 
-clang++ -D_M_IX86 -DGCC -m32 --shared -fPIC -o $OUT/x86/MathNet.Numerics.MKL.dll -I$MKL/include -I../Common ../MKL/memory.c ../MKL/capabilities.cpp ../MKL/vector_functions.c ../MKL/blas.c ../MKL/lapack.cpp $MKL/lib/libmkl_intel.a $MKL/lib/libmkl_core.a $MKL/lib/libmkl_intel_thread.a  -L$OPENMP -liomp5 -lpthread -lm  
+clang++ -std=c++11 -D_M_IX86 -DGCC -m32 --shared -fPIC -o $OUT/x86/MathNet.Numerics.MKL.dll -I$MKL/include -I../Common -I../MKL ../MKL/memory.c ../MKL/capabilities.cpp ../MKL/vector_functions.c ../Common/blas.c ../Common/lapack.cpp $MKL/lib/libmkl_intel_lp64.a $MKL/lib/libmkl_core.a $MKL/lib/libmkl_intel_thread.a -L$OPENMP -liomp5 -lpthread -lm
 
 cp $OPENMP/libiomp5.dylib  $OUT/x86/


### PR DESCRIPTION
Hello,

I've updated the mkl_build script to build the MKL native provider on OSX thanks to directions from @cuda and @cdrnet. I've succeed in building the native provider on my mac and run the example given in the doc (matrix multiplication).

I've also enriched the OSX section of the doc file (MKL.md) so people not familiar with the  build process (like me) can do it themselves more easily.

Lionel

PS : I'm running OSX 10.10.5 with intel Parallel Studio XE 2016 on a macbook pro end 2011 - core i7 2.8 GHz.