### PR TITLE
Histogram: Adding data equal to the lower bound

### DIFF
--- a/src/Numerics/Statistics/Histogram.cs
+++ b/src/Numerics/Statistics/Histogram.cs
@@ -344,7 +344,7 @@ namespace MathNet.Numerics.Statistics
             // Sort if needed.
             LazySort();
 
-            if (d < LowerBound)
+            if (d <= LowerBound)
             {
                 // Make the lower bound just slightly smaller than the datapoint so it is contained in this bucket.
                 _buckets[0].LowerBound = d.Decrement();

--- a/src/UnitTests/StatisticsTests/HistogramTests.cs
+++ b/src/UnitTests/StatisticsTests/HistogramTests.cs
@@ -349,6 +349,18 @@ namespace MathNet.Numerics.UnitTests.StatisticsTests
         }
 
         /// <summary>
+        /// Add data equal to the lower bound of a histogram.
+        /// </summary>
+        [Test]
+        public void AddDataEqualToLowerBound()
+        {
+            var h = new Histogram(new[] { 1.0, 5.0, 10.0 }, 3, 0.0, 10.0);
+            Assert.DoesNotThrow(() => h.AddData(0.0));
+            
+            Assert.AreEqual(2, h[0].Count);
+        }
+
+        /// <summary>
         /// Small dataset histogram without bounds.
         /// </summary>
         [Test]


### PR DESCRIPTION
As described in issue https://github.com/mathnet/mathnet-numerics/issues/323, adding values that are equal to the lower bound of a histogram result in an exception. Values slightly lower than that bound, will decrease the lower bound automatically as required.

Therefore, i propose to initiate this behavior on all values *equal* or lower that the boundary.