### PR TITLE
More accurate algorithms for Complex

### DIFF
--- a/src/Numerics/Complex32.cs
+++ b/src/Numerics/Complex32.cs
@@ -180,7 +180,7 @@ namespace MathNet.Numerics
         /// <summary>
         /// Gets the magnitude (or absolute value) of a complex number.
         /// </summary>
-        /// <remarks>Assuming that magnitude of (inf,a) and (a,inf) is NaN and magnitude of (inf,inf) is inf</remarks>
+        /// <remarks>Assuming that magnitude of (inf,a) and (a,inf) and (inf,inf) is inf and (NaN,a), (a,NaN) and (NaN,NaN) is NaN</remarks>
         /// <returns>The magnitude of the current instance.</returns>
         public float Magnitude
         {

--- a/src/Numerics/Complex32.cs
+++ b/src/Numerics/Complex32.cs
@@ -187,10 +187,12 @@ namespace MathNet.Numerics
             [TargetedPatchingOptOut("Performance critical to inline this type of method across NGen image boundaries")]
             get
             {
+                if (float.IsNaN(_real) || float.IsNaN(_imag))
+                    return float.NaN;
+                if (float.IsInfinity(_real) || float.IsInfinity(_imag))
+                    return float.PositiveInfinity;
                 float a = Math.Abs(_real);
                 float b = Math.Abs(_imag);
-                if (float.IsPositiveInfinity(a) && float.IsPositiveInfinity(b))
-                    return float.PositiveInfinity;
                 if (a > b)
                 {
                     double tmp = b / a;

--- a/src/Numerics/Complex32.cs
+++ b/src/Numerics/Complex32.cs
@@ -180,6 +180,7 @@ namespace MathNet.Numerics
         /// <summary>
         /// Gets the magnitude (or absolute value) of a complex number.
         /// </summary>
+        /// <remarks>Assuming that magnitude of (inf,a) and (a,inf) is NaN and magnitude of (inf,inf) is inf</remarks>
         /// <returns>The magnitude of the current instance.</returns>
         public float Magnitude
         {
@@ -188,7 +189,7 @@ namespace MathNet.Numerics
             {
                 float a = Math.Abs(_real);
                 float b = Math.Abs(_imag);
-                if (float.IsPositiveInfinity(a) && float.IsPositiveInfinity(b)) 
+                if (float.IsPositiveInfinity(a) && float.IsPositiveInfinity(b))
                     return float.PositiveInfinity;
                 if (a > b)
                 {

--- a/src/Numerics/Complex32.cs
+++ b/src/Numerics/Complex32.cs
@@ -188,6 +188,8 @@ namespace MathNet.Numerics
             {
                 float a = Math.Abs(_real);
                 float b = Math.Abs(_imag);
+                if (float.IsPositiveInfinity(a) && float.IsPositiveInfinity(b))
+                    return float.PositiveInfinity;
                 if (a > b)
                 {
                     double tmp = b / a;
@@ -201,8 +203,8 @@ namespace MathNet.Numerics
                 else
                 {
                     double tmp = a / b;
-                    return b*(float)Math.Sqrt(1.0f + tmp*tmp);
-                } 
+                    return b * (float)Math.Sqrt(1.0f + tmp * tmp);
+                }
             }
         }
 
@@ -504,9 +506,9 @@ namespace MathNet.Numerics
         /// </summary>
         public Tuple<Complex32, Complex32, Complex32> CubicRoots()
         {
-            float r = (float)Math.Pow(Magnitude, 1d/3d);
-            float theta = Phase/3;
-            const float shift = (float)Constants.Pi2/3;
+            float r = (float)Math.Pow(Magnitude, 1d / 3d);
+            float theta = Phase / 3;
+            const float shift = (float)Constants.Pi2 / 3;
             return new Tuple<Complex32, Complex32, Complex32>(
                 FromPolarCoordinates(r, theta),
                 FromPolarCoordinates(r, theta + shift),
@@ -676,7 +678,7 @@ namespace MathNet.Numerics
             float r = d / c;
             float t = 1 / (c + d * r);
             float e, f;
-            if (r!=0.0f) // one can use r >= float.Epsilon || r <= float.Epsilon instead
+            if (r != 0.0f) // one can use r >= float.Epsilon || r <= float.Epsilon instead
             {
                 e = (a + b * r) * t;
                 f = (b - a * r) * t;

--- a/src/Numerics/Complex32.cs
+++ b/src/Numerics/Complex32.cs
@@ -641,7 +641,8 @@ namespace MathNet.Numerics
         }
 
         /// <summary>Division operator. Divides a complex number by another.</summary>
-        /// <remarks>Enchanted Smith's algorithm for dividing two complex numbers </remarks>
+        /// <remarks>Enhanced Smith's algorithm for dividing two complex numbers </remarks>
+        /// <see cref="InternalDiv(float, float, float, float, bool)"/>
         /// <returns>The result of the division.</returns>
         /// <param name="dividend">The dividend.</param>
         /// <param name="divisor">The divisor.</param>
@@ -694,6 +695,8 @@ namespace MathNet.Numerics
         }
 
         /// <summary>Division operator. Divides a float value by a complex number.</summary>
+        /// <remarks>Algorithm based on Smith's algorithm</remarks>
+        /// <see cref="InternalDiv(float, float, float, float, bool)"/> 
         /// <returns>The result of the division.</returns>
         /// <param name="dividend">The dividend.</param>
         /// <param name="divisor">The divisor.</param>
@@ -708,9 +711,11 @@ namespace MathNet.Numerics
             {
                 return PositiveInfinity;
             }
-
-            var zmod = divisor.MagnitudeSquared;
-            return new Complex32(dividend * divisor._real / zmod, -dividend * divisor._imag / zmod);
+            float c = divisor.Real;
+            float d = divisor.Imaginary;
+            if (Math.Abs(d) <= Math.Abs(c))
+                return InternalDiv(dividend, 0, c, d, false);
+            return InternalDiv(0, dividend, d, c, true);
         }
 
         /// <summary>Division operator. Divides a complex number by a float value.</summary>

--- a/src/Numerics/Complex32.cs
+++ b/src/Numerics/Complex32.cs
@@ -504,9 +504,9 @@ namespace MathNet.Numerics
         /// </summary>
         public Tuple<Complex32, Complex32, Complex32> CubicRoots()
         {
-            float r = (float)Math.Pow(Magnitude, 1d / 3d);
-            float theta = Phase / 3;
-            const float shift = (float)Constants.Pi2 / 3;
+            float r = (float)Math.Pow(Magnitude, 1d/3d);
+            float theta = Phase/3;
+            const float shift = (float)Constants.Pi2/3;
             return new Tuple<Complex32, Complex32, Complex32>(
                 FromPolarCoordinates(r, theta),
                 FromPolarCoordinates(r, theta + shift),

--- a/src/Numerics/Complex32.cs
+++ b/src/Numerics/Complex32.cs
@@ -188,7 +188,7 @@ namespace MathNet.Numerics
             {
                 float a = Math.Abs(_real);
                 float b = Math.Abs(_imag);
-                if (float.IsPositiveInfinity(a) && float.IsPositiveInfinity(b))
+                if (float.IsPositiveInfinity(a) || float.IsPositiveInfinity(b)) 
                     return float.PositiveInfinity;
                 if (a > b)
                 {

--- a/src/Numerics/Complex32.cs
+++ b/src/Numerics/Complex32.cs
@@ -188,7 +188,7 @@ namespace MathNet.Numerics
             {
                 float a = Math.Abs(_real);
                 float b = Math.Abs(_imag);
-                if (float.IsPositiveInfinity(a) || float.IsPositiveInfinity(b)) 
+                if (float.IsPositiveInfinity(a) && float.IsPositiveInfinity(b)) 
                     return float.PositiveInfinity;
                 if (a > b)
                 {

--- a/src/UnitTests/ComplexTests/Complex32Test.cs
+++ b/src/UnitTests/ComplexTests/Complex32Test.cs
@@ -24,15 +24,14 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 // </copyright>
 
-using NUnit.Framework;
 using System;
+using NUnit.Framework;
 
 namespace MathNet.Numerics.UnitTests.ComplexTests
 {
 #if NOSYSNUMERICS
     using Complex = Numerics.Complex;
-#else
-    using System.Diagnostics;
+#else 
     using Complex = System.Numerics.Complex;
 #endif
 

--- a/src/UnitTests/ComplexTests/Complex32Test.cs
+++ b/src/UnitTests/ComplexTests/Complex32Test.cs
@@ -436,7 +436,21 @@ namespace MathNet.Numerics.UnitTests.ComplexTests
             Assert.AreEqual(new Complex32(-(float)Math.Pow(10, 20), (float)Math.Pow(10, -14)), first / second);
 
         }
+        /// <summary>
+        /// Can divide float/complex without overflow
+        /// </summary>
+        [Test]
+        public void CanDodgeOverflowDivisionFloat()
+        {
 
+            var first = new Complex32((float)Math.Pow(10, 25), (float)Math.Pow(10, -25));
+            float second = (float)Math.Pow(10, -37);
+            float third = (float)Math.Pow(10, 37);
+            Assert.AreEqual(new Complex32(0, 0), second / first); // it's (10^-62,10^-112) thus overflow
+            Assert.AreEqual(new Complex32((float)Math.Pow(10, 12), (float)Math.Pow(10, -38)), third / first); 
+            Assert.AreEqual(new Complex32((float)Math.Pow(10, -28), -(float)Math.Pow(10, 12)), third / new Complex32((float)Math.Pow(10, -25), (float)Math.Pow(10, 25))); 
+
+        }
         /// <summary>
         /// Can multiple a complex number and a double using operators.
         /// </summary>
@@ -574,7 +588,7 @@ namespace MathNet.Numerics.UnitTests.ComplexTests
         {
             Assert.AreEqual((float)Math.Sqrt(2) * float.Epsilon, new Complex32(float.Epsilon, float.Epsilon).Magnitude);
             Assert.AreEqual(float.Epsilon, new Complex32(0, float.Epsilon).Magnitude);
-            Assert.AreEqual((float)(Math.Pow(10,30) * Math.Sqrt(2)), new Complex32((float)Math.Pow(10, 30), (float)Math.Pow(10, 30)).Magnitude);
+            Assert.AreEqual((float)(Math.Pow(10, 30) * Math.Sqrt(2)), new Complex32((float)Math.Pow(10, 30), (float)Math.Pow(10, 30)).Magnitude);
 
         }
         /// <summary>

--- a/src/UnitTests/ComplexTests/Complex32Test.cs
+++ b/src/UnitTests/ComplexTests/Complex32Test.cs
@@ -443,12 +443,26 @@ namespace MathNet.Numerics.UnitTests.ComplexTests
         public void CanDodgeOverflowDivisionFloat()
         {
 
-            var first = new Complex32((float)Math.Pow(10, 25), (float)Math.Pow(10, -25));
-            float second = (float)Math.Pow(10, -37);
-            float third = (float)Math.Pow(10, 37);
-            Assert.AreEqual(new Complex32(0, 0), second / first); // it's (10^-62,10^-112) thus overflow
-            Assert.AreEqual(new Complex32((float)Math.Pow(10, 12), (float)Math.Pow(10, -38)), third / first); 
-            Assert.AreEqual(new Complex32((float)Math.Pow(10, -28), -(float)Math.Pow(10, 12)), third / new Complex32((float)Math.Pow(10, -25), (float)Math.Pow(10, 25))); 
+            var firstComplex = new Complex32((float)Math.Pow(10, 25), (float)Math.Pow(10, -25));
+            float firstFloat = (float)Math.Pow(10, -37);
+            float secondFloat = (float)Math.Pow(10, 37);
+
+            Assert.AreEqual(new Complex32(0, 0), firstFloat / firstComplex); // it's (10^-62,10^-112) thus overflow to 0
+            Assert.AreEqual(new Complex32((float)Math.Pow(10, 12), (float)Math.Pow(10, -38)), secondFloat / firstComplex);
+
+            var secondComplex = new Complex32((float)Math.Pow(10, -25), (float)Math.Pow(10, 25));
+            Assert.AreEqual(new Complex32(0, 0), firstFloat / secondComplex);// it's (10^-112,10^-62) thus overflow to 0
+            Assert.AreEqual(new Complex32((float)Math.Pow(10, -38), -(float)Math.Pow(10, 12)), secondFloat / secondComplex);
+
+
+
+            float thirdFloat = (float)Math.Pow(10, 13);
+            var thirdComplex = new Complex32((float)Math.Pow(10, -25), (float)Math.Pow(10, -25));
+            Assert.AreEqual(new Complex32(5.0f * (float)Math.Pow(10, 37), -5.0f * (float)Math.Pow(10, 37)), thirdFloat / thirdComplex);
+
+            var fourthFloat = (float)Math.Pow(10, -30);
+            var fourthComplex = new Complex32((float)Math.Pow(10, -30), (float)Math.Pow(10, -30));
+            Assert.AreEqual(new Complex32(0.5f, -0.5f), fourthFloat / fourthComplex);
 
         }
         /// <summary>

--- a/src/UnitTests/ComplexTests/Complex32Test.cs
+++ b/src/UnitTests/ComplexTests/Complex32Test.cs
@@ -24,14 +24,15 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 // </copyright>
 
-using System;
 using NUnit.Framework;
+using System;
 
 namespace MathNet.Numerics.UnitTests.ComplexTests
 {
 #if NOSYSNUMERICS
     using Complex = Numerics.Complex;
 #else
+    using System.Diagnostics;
     using Complex = System.Numerics.Complex;
 #endif
 
@@ -417,6 +418,25 @@ namespace MathNet.Numerics.UnitTests.ComplexTests
             Assert.AreEqual(new Complex32(-2, 0), new Complex32(4, -4) / new Complex32(-2, 2));
             Assert.AreEqual(Complex32.PositiveInfinity, Complex32.One / Complex32.Zero);
         }
+        /// <summary>
+        /// Can divide without overflow.
+        /// </summary> 
+        [Test]
+        public void CanDodgeOverflowDivision()
+        {
+            var first = new Complex32((float)Math.Pow(10, 37), (float)Math.Pow(10, -37));
+            var second = new Complex32((float)Math.Pow(10, 25), (float)Math.Pow(10, -25));
+            Assert.AreEqual(new Complex32((float)Math.Pow(10, 12), (float)Math.Pow(10, -38)), first / second);
+
+            first = new Complex32(-(float)Math.Pow(10, 37), (float)Math.Pow(10, -37));
+            second = new Complex32((float)Math.Pow(10, 25), (float)Math.Pow(10, -25));
+            Assert.AreEqual(new Complex32(-(float)Math.Pow(10, 12), (float)Math.Pow(10, -38)), first / second);
+
+            first = new Complex32((float)Math.Pow(10, -37), (float)Math.Pow(10, 37));
+            second = new Complex32((float)Math.Pow(10, -17), -(float)Math.Pow(10, 17));
+            Assert.AreEqual(new Complex32(-(float)Math.Pow(10, 20), (float)Math.Pow(10, -14)), first / second);
+
+        }
 
         /// <summary>
         /// Can multiple a complex number and a double using operators.
@@ -547,7 +567,17 @@ namespace MathNet.Numerics.UnitTests.ComplexTests
         {
             Assert.AreEqual(expected, new Complex32(real, imag).Magnitude);
         }
+        /// <summary>
+        /// Can calculate magnitude without overflow
+        /// </summary>
+        [Test]
+        public void CanDodgeOverflowMagnitude()
+        {
+            Assert.AreEqual((float)Math.Sqrt(2) * float.Epsilon, new Complex32(float.Epsilon, float.Epsilon).Magnitude);
+            Assert.AreEqual(float.Epsilon, new Complex32(0, float.Epsilon).Magnitude);
+            Assert.AreEqual((float)(Math.Pow(10,30) * Math.Sqrt(2)), new Complex32((float)Math.Pow(10, 30), (float)Math.Pow(10, 30)).Magnitude);
 
+        }
         /// <summary>
         /// Can compute sign.
         /// </summary>


### PR DESCRIPTION
I changed magnitude because of overflow for big numbers, It's now based on simple mathematical observation that Sqrt(a^2+b^2) = |a| * Sqrt(1+b/a*b/a). 
Problem with squaring might occur for example when we had a or b bigger than (2 *10^19) because of (2 *10^19)^2 == 4 *10^38 > 3.4 *10^38 == float.MaxValue.  

Second change is in division. Now there will be no Nan or overflow when dividing two numbers with real/imaginary values near float.epsilon. It's based on Smith's algorithm but is enhanced because Smith's sometimes returned bad imaginary values. 

For more examples see unit test in my commit.