### PR TITLE
Moved initialization of LinearAlgebraProvider to reduce exceptions

### DIFF
--- a/src/Numerics/Control.cs
+++ b/src/Numerics/Control.cs
@@ -46,6 +46,7 @@ namespace MathNet.Numerics
         static int _parallelizeOrder;
         static int _parallelizeElements;
         static ILinearAlgebraProvider _linearAlgebraProvider;
+        static readonly object _staticLock = new object();
 
         static Control()
         {
@@ -64,48 +65,50 @@ namespace MathNet.Numerics
             _parallelizeOrder = 64;
             _parallelizeElements = 300;
             TaskScheduler = TaskScheduler.Default;
+        }
 
-            // Linear Algebra Provider
-#if PORTABLE
-            LinearAlgebraProvider = new ManagedLinearAlgebraProvider();
-#else
-            try
+        private static void InitializeDefaultLinearAlgebraProvider()
+        {
+            lock (_staticLock)
             {
-                var value = Environment.GetEnvironmentVariable(EnvVarLAProvider);
-                switch (value != null ? value.ToUpperInvariant() : string.Empty)
+                if (_linearAlgebraProvider == null)
                 {
 #if NATIVE
-                    case "MKL":
-                        UseNativeMKL();
-                        break;
-
-                    case "CUDA":
-                        UseNativeCUDA();
-                        break;
-
-                    case "OPENBLAS":
-                        UseNativeOpenBLAS();
-                        break;
-
-                    default:
-                        if (!TryUseNative())
+                    try
+                    {
+                        var value = Environment.GetEnvironmentVariable(EnvVarLAProvider);
+                        switch (value != null ? value.ToUpperInvariant() : string.Empty)
                         {
-                            UseManaged();
+                            case "MKL":
+                                UseNativeMKL();
+                                break;
+
+                            case "CUDA":
+                                UseNativeCUDA();
+                                break;
+
+                            case "OPENBLAS":
+                                UseNativeOpenBLAS();
+                                break;
+
+                            default:
+                                if (!TryUseNative())
+                                {
+                                    UseManaged();
+                                }
+                                break;
                         }
-                        break;
-#else
-                    default:
+                    }
+                    catch
+                    {
+                        // We don't care about any failures here at all (because "auto")
                         UseManaged();
-                        break;
+                    }
+#else
+                    UseManaged();
 #endif
                 }
             }
-            catch
-            {
-                // We don't care about any failures here at all (because "auto")
-                UseManaged();
-            }
-#endif
         }
 
         public static void UseManaged()
@@ -261,7 +264,13 @@ namespace MathNet.Numerics
         /// <value>The linear algebra provider.</value>
         public static ILinearAlgebraProvider LinearAlgebraProvider
         {
-            get { return _linearAlgebraProvider; }
+            get
+            {
+                if (_linearAlgebraProvider == null)
+                    InitializeDefaultLinearAlgebraProvider();
+
+                return _linearAlgebraProvider;
+            }
             set
             {
                 value.InitializeVerify();


### PR DESCRIPTION
Moved initialization of default LinearAlgebraProvider out of Control.ConfigureAuto to prevent unnecessary initialization and exceptions. Initialization code moved to new method, InitializeDefaultLinearAlgebraProvider(), which is called from the LinearAlgebraProvider getter only if the current _linearAlgebraProvider is null. This prevents trying to initialize multiple providers when calling any of the 'UseXX' methods.