### PR TITLE
Added quaternion in C#

### DIFF
--- a/src/Numerics/Numerics.csproj
+++ b/src/Numerics/Numerics.csproj
@@ -214,6 +214,7 @@
     <Compile Include="Exceptions.cs" />
     <Compile Include="Providers\LinearAlgebra\OpenBlas\OpenBlasProviderCapabilities.cs" />
     <Compile Include="Providers\NativeProviderLoader.cs" />
+    <Compile Include="Quaternion32.cs" />
     <Compile Include="Random\SystemRandomSource.cs" />
     <Compile Include="Random\RandomSeed.cs" />
     <Compile Include="RootFinding\Broyden.cs" />

--- a/src/Numerics/Quaternion32.cs
+++ b/src/Numerics/Quaternion32.cs
@@ -1,0 +1,145 @@
+﻿// <copyright file="Quaternion.cs" company="Math.NET">
+// Math.NET Numerics, part of the Math.NET Project
+// http://numerics.mathdotnet.com
+// http://github.com/mathnet/mathnet-numerics
+// http://mathnetnumerics.codeplex.com
+//
+// Copyright (c) 2009-2010 Math.NET
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+
+namespace MathNet.Numerics
+{
+    using System;
+
+    /// <summary>
+    /// 32-bit single precision Quaternion number class.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The class <c>Quaternion32</c> provides all basic operations on Quaternion numbers. 
+    /// All the operators <c>+</c>, <c>-</c>,
+    /// <c>*</c>, <c>/</c>, <c>==</c>, <c>!=</c> are defined in the
+    /// canonical way. 
+    /// </para>
+    /// </remarks>
+    public struct Quaternion32 : IFormattable, IEquatable<Quaternion32>
+    {
+        private float w, x, y, z;
+        #region constructors
+        public Quaternion32(float w, float x, float y, float z)
+        {
+            this.w = w;
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
+
+        public Quaternion32(Complex32 a, Complex32 b)
+        {
+            w = a.Real;
+            x = a.Imaginary;
+            y = b.Real;
+            z = b.Imaginary;
+        }
+        #endregion
+        #region operators
+        public static Quaternion32 operator +(Quaternion32 q1, Quaternion32 q2)
+        {
+            return new Quaternion32(q1.w + q2.w, q1.x + q2.x, q1.y + q2.y, q1.z + q2.z);
+        }
+        public static Quaternion32 operator -(Quaternion32 q1, Quaternion32 q2)
+        {
+            return new Quaternion32(q1.w - q2.w, q1.x - q2.x, q1.y - q2.y, q1.z - q2.z);
+        }
+
+        public static Quaternion32 operator *(Quaternion32 q1, Quaternion32 q2)
+        {
+            return new Quaternion32(
+                 q1.w * q2.w - q1.x * q2.x - q1.y * q2.y - q1.z * q2.z,
+                q1.w * q2.x + q1.x * q2.w - q1.y * q2.z + q1.z * q2.y,
+                q1.w * q2.y + q1.x * q2.z + q1.y * q2.w - q1.z * q2.x,
+                q1.w * q2.z - q1.x * q2.y + q1.y * q2.x + q1.z * q2.w
+                );
+        }
+
+        public static Quaternion32 operator /(Quaternion32 q1, float f)
+        {
+            return new Quaternion32(q1.w / f, q1.x / f, q1.y / f, q1.z / f);
+        }
+        #endregion
+
+        #region others
+
+        public float MagnitudeSquared
+        {
+            get { return w * w + x * x + y * y + z * z; }
+        }
+
+        public float Magnitude
+        {
+            //TODO : create more robust magnitude
+            get { return (float)Math.Sqrt(MagnitudeSquared); }
+        }
+
+        public float DotProduct(Quaternion32 q1, Quaternion32 q2)
+        {
+            return q1.x * q2.x + q1.y * q2.y + q1.z * q2.z + q1.w * q2.w;
+        }
+        public Quaternion32 Inverse()
+        {
+            return Conjugate() / MagnitudeSquared;
+        }
+        public Quaternion32 Normalize()
+        {
+            var magnitude = Magnitude;
+            return new Quaternion32(w / magnitude, x / magnitude, y / magnitude, z / magnitude);
+        }
+        public static Quaternion32 Normalize(Quaternion32 quat)
+        {
+            return quat.Normalize();
+        }
+        public Quaternion32 Conjugate()
+        {
+            return new Quaternion32(w, -x, -y, -z);
+        }
+        public static Quaternion32 Conjugate(Quaternion32 quat)
+        {
+            return quat.Conjugate();
+        }
+        #endregion
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            return string.Format(formatProvider, "({0}, {1}, {2}, {3})",
+                w.ToString(format, formatProvider),
+                x.ToString(format, formatProvider),
+                y.ToString(format, formatProvider),
+                z.ToString(format, formatProvider));
+        }
+
+        public bool Equals(Quaternion32 other)
+        {
+            return w.AlmostEqual(other.w) && x.AlmostEqual(other.x) && y.AlmostEqual(other.y) && z.AlmostEqual(other.z);
+        }
+    }
+}

--- a/src/Numerics/Quaternion32.cs
+++ b/src/Numerics/Quaternion32.cs
@@ -31,8 +31,6 @@
 namespace MathNet.Numerics
 {
     using System;
-    using Distributions;
-
     /// <summary>
     /// 32-bit single precision Quaternion number class.
     /// </summary>
@@ -49,6 +47,7 @@ namespace MathNet.Numerics
     /// </remarks>
     public struct Quaternion32 : IFormattable, IEquatable<Quaternion32>
     {
+        //TODO : rotations
         private float a1, a2, a3, a4;
         #region constructors
         public Quaternion32(float a1, float a2, float a3, float a4)
@@ -120,7 +119,7 @@ namespace MathNet.Numerics
         }
         public static Quaternion32 operator /(float f, Quaternion32 q1)
         {
-            //TODO : More robust divisionFdo
+            //TODO : More robust division - possible overflow
             return f * q1.Inverse();
         }
         public static bool operator ==(Quaternion32 q1, Quaternion32 q2)
@@ -132,6 +131,11 @@ namespace MathNet.Numerics
         {
             return !(q1 == q2);
         }
+
+        public static Quaternion32 operator -(Quaternion32 q)
+        {
+            return new Quaternion32(-q.a1, -q.a2, -q.a3, -q.a4);
+        }
         #endregion 
         #region operations
 
@@ -142,7 +146,7 @@ namespace MathNet.Numerics
 
         public float Norm
         {
-            //TODO : create more robust magnitude
+            //TODO : create more robust norm - possible overflow
             get { return (float)Math.Sqrt(NormSquared); }
         }
 
@@ -172,7 +176,10 @@ namespace MathNet.Numerics
             return quat.Conjugate();
         }
         #endregion
-
+        #region const members
+        public static readonly Quaternion32 One = new Quaternion32(1, 0, 0, 0);
+        public static readonly Quaternion32 Zero = new Quaternion32(0, 0, 0, 0);
+        #endregion
         public bool IsNan
         {
             get { return float.IsNaN(a1) || float.IsNaN(a2) || float.IsNaN(a3) || float.IsNaN(a4); }
@@ -182,9 +189,6 @@ namespace MathNet.Numerics
         {
             get { return float.IsInfinity(a1) || float.IsInfinity(a2) || float.IsInfinity(a3) || float.IsInfinity(a4); }
         }
-
-        public static readonly Quaternion32 One = new Quaternion32(1, 0, 0, 0);
-        public static readonly Quaternion32 Zero = new Quaternion32(0, 0, 0, 0);
         public string ToString(string format, IFormatProvider formatProvider)
         {
             return string.Format(formatProvider, "({0}, {1}, {2}, {3})",

--- a/src/Numerics/Quaternion32.cs
+++ b/src/Numerics/Quaternion32.cs
@@ -31,6 +31,7 @@
 namespace MathNet.Numerics
 {
     using System;
+    using Distributions;
 
     /// <summary>
     /// 32-bit single precision Quaternion number class.
@@ -42,78 +43,121 @@ namespace MathNet.Numerics
     /// <c>*</c>, <c>/</c>, <c>==</c>, <c>!=</c> are defined in the
     /// canonical way. 
     /// </para>
+    /// <para>
+    /// Class is based on http://web.cs.iastate.edu/~cs577/handouts/quaternion.pdf and http://mathworld.wolfram.com/Quaternion.html
+    /// </para>
     /// </remarks>
     public struct Quaternion32 : IFormattable, IEquatable<Quaternion32>
     {
-        private float w, x, y, z;
+        private float a1, a2, a3, a4;
         #region constructors
-        public Quaternion32(float w, float x, float y, float z)
+        public Quaternion32(float a1, float a2, float a3, float a4)
         {
-            this.w = w;
-            this.x = x;
-            this.y = y;
-            this.z = z;
+            this.a1 = a1;
+            this.a2 = a2;
+            this.a3 = a3;
+            this.a4 = a4;
         }
 
         public Quaternion32(Complex32 a, Complex32 b)
         {
-            w = a.Real;
-            x = a.Imaginary;
-            y = b.Real;
-            z = b.Imaginary;
+            a1 = a.Real;
+            a2 = a.Imaginary;
+            a3 = b.Real;
+            a4 = b.Imaginary;
         }
         #endregion
         #region operators
         public static Quaternion32 operator +(Quaternion32 q1, Quaternion32 q2)
         {
-            return new Quaternion32(q1.w + q2.w, q1.x + q2.x, q1.y + q2.y, q1.z + q2.z);
+            return new Quaternion32(q1.a1 + q2.a1, q1.a2 + q2.a2, q1.a3 + q2.a3, q1.a4 + q2.a4);
+        }
+
+        public static Quaternion32 operator +(Quaternion32 q1, float f)
+        {
+            return new Quaternion32(q1.a1 + f, q1.a2, q1.a3, q1.a4);
+        }
+
+        public static Quaternion32 operator +(float f, Quaternion32 q1)
+        {
+            return q1 + f;
         }
         public static Quaternion32 operator -(Quaternion32 q1, Quaternion32 q2)
         {
-            return new Quaternion32(q1.w - q2.w, q1.x - q2.x, q1.y - q2.y, q1.z - q2.z);
+            return new Quaternion32(q1.a1 - q2.a1, q1.a2 - q2.a2, q1.a3 - q2.a3, q1.a4 - q2.a4);
         }
 
+        public static Quaternion32 operator -(Quaternion32 q1, float f)
+        {
+            return new Quaternion32(q1.a1 - f, q1.a2, q1.a3, q1.a4);
+        }
+
+        public static Quaternion32 operator -(float f, Quaternion32 q1)
+        {
+            return new Quaternion32(f - q1.a1, q1.a2, q1.a3, q1.a4);
+        }
         public static Quaternion32 operator *(Quaternion32 q1, Quaternion32 q2)
         {
             return new Quaternion32(
-                 q1.w * q2.w - q1.x * q2.x - q1.y * q2.y - q1.z * q2.z,
-                q1.w * q2.x + q1.x * q2.w - q1.y * q2.z + q1.z * q2.y,
-                q1.w * q2.y + q1.x * q2.z + q1.y * q2.w - q1.z * q2.x,
-                q1.w * q2.z - q1.x * q2.y + q1.y * q2.x + q1.z * q2.w
+                 q1.a1 * q2.a1 - q1.a2 * q2.a2 - q1.a3 * q2.a3 - q1.a4 * q2.a4,
+                q1.a1 * q2.a2 + q1.a2 * q2.a1 + q1.a3 * q2.a4 - q1.a4 * q2.a3,
+                q1.a1 * q2.a3 - q1.a2 * q2.a4 + q1.a3 * q2.a1 + q1.a4 * q2.a2,
+                q1.a1 * q2.a4 + q1.a2 * q2.a3 - q1.a3 * q2.a2 + q1.a4 * q2.a1
                 );
+        }
+        public static Quaternion32 operator *(Quaternion32 q1, float f)
+        {
+            return new Quaternion32(q1.a1 * f, q1.a2 * f, q1.a3 * f, q1.a4 * f);
+        }
+        public static Quaternion32 operator *(float f, Quaternion32 q1)
+        {
+            return q1 * f;
         }
 
         public static Quaternion32 operator /(Quaternion32 q1, float f)
         {
-            return new Quaternion32(q1.w / f, q1.x / f, q1.y / f, q1.z / f);
+            return new Quaternion32(q1.a1 / f, q1.a2 / f, q1.a3 / f, q1.a4 / f);
         }
-        #endregion
-
-        #region others
-
-        public float MagnitudeSquared
+        public static Quaternion32 operator /(float f, Quaternion32 q1)
         {
-            get { return w * w + x * x + y * y + z * z; }
+            //TODO : More robust divisionFdo
+            return f * q1.Inverse();
+        }
+        public static bool operator ==(Quaternion32 q1, Quaternion32 q2)
+        {
+            return q1.Equals(q2);
         }
 
-        public float Magnitude
+        public static bool operator !=(Quaternion32 q1, Quaternion32 q2)
+        {
+            return !(q1 == q2);
+        }
+        #endregion 
+        #region operations
+
+        public float NormSquared
+        {
+            get { return a1 * a1 + a2 * a2 + a3 * a3 + a4 * a4; }
+        }
+
+        public float Norm
         {
             //TODO : create more robust magnitude
-            get { return (float)Math.Sqrt(MagnitudeSquared); }
+            get { return (float)Math.Sqrt(NormSquared); }
         }
 
-        public float DotProduct(Quaternion32 q1, Quaternion32 q2)
+        public static float DotProduct(Quaternion32 q1, Quaternion32 q2)
         {
-            return q1.x * q2.x + q1.y * q2.y + q1.z * q2.z + q1.w * q2.w;
+            return q1.a2 * q2.a2 + q1.a3 * q2.a3 + q1.a4 * q2.a4 + q1.a1 * q2.a1;
         }
         public Quaternion32 Inverse()
         {
-            return Conjugate() / MagnitudeSquared;
+            return Conjugate() / NormSquared;
         }
         public Quaternion32 Normalize()
         {
-            var magnitude = Magnitude;
-            return new Quaternion32(w / magnitude, x / magnitude, y / magnitude, z / magnitude);
+            var norm = Norm;
+            return new Quaternion32(a1 / norm, a2 / norm, a3 / norm, a4 / norm);
         }
         public static Quaternion32 Normalize(Quaternion32 quat)
         {
@@ -121,25 +165,38 @@ namespace MathNet.Numerics
         }
         public Quaternion32 Conjugate()
         {
-            return new Quaternion32(w, -x, -y, -z);
+            return new Quaternion32(a1, -a2, -a3, -a4);
         }
         public static Quaternion32 Conjugate(Quaternion32 quat)
         {
             return quat.Conjugate();
         }
         #endregion
+
+        public bool IsNan
+        {
+            get { return float.IsNaN(a1) || float.IsNaN(a2) || float.IsNaN(a3) || float.IsNaN(a4); }
+        }
+
+        public bool IsInfinity
+        {
+            get { return float.IsInfinity(a1) || float.IsInfinity(a2) || float.IsInfinity(a3) || float.IsInfinity(a4); }
+        }
+
+        public static readonly Quaternion32 One = new Quaternion32(1, 0, 0, 0);
+        public static readonly Quaternion32 Zero = new Quaternion32(0, 0, 0, 0);
         public string ToString(string format, IFormatProvider formatProvider)
         {
             return string.Format(formatProvider, "({0}, {1}, {2}, {3})",
-                w.ToString(format, formatProvider),
-                x.ToString(format, formatProvider),
-                y.ToString(format, formatProvider),
-                z.ToString(format, formatProvider));
+                a1.ToString(format, formatProvider),
+                a2.ToString(format, formatProvider),
+                a3.ToString(format, formatProvider),
+                a4.ToString(format, formatProvider));
         }
 
         public bool Equals(Quaternion32 other)
         {
-            return w.AlmostEqual(other.w) && x.AlmostEqual(other.x) && y.AlmostEqual(other.y) && z.AlmostEqual(other.z);
+            return a1.AlmostEqual(other.a1) && a2.AlmostEqual(other.a2) && a3.AlmostEqual(other.a3) && a4.AlmostEqual(other.a4);
         }
     }
 }

--- a/src/UnitTests/QuaternionsTests/Quaternions32Tests.cs
+++ b/src/UnitTests/QuaternionsTests/Quaternions32Tests.cs
@@ -1,6 +1,5 @@
 ﻿namespace MathNet.Numerics.UnitTests.QuaternionsTests
 {
-    using System.Security.Cryptography.X509Certificates;
     using NUnit.Framework;
     /// <summary>
     /// Complex32 tests.
@@ -11,14 +10,17 @@
     [TestFixture]
     public class Quaternions32Tests
     {
+        //TODO : dotproduct, equality operator,infs,nans,tostring,norm,conjugation
         /// <summary>
         /// Can add a quaternions using operator.
         /// </summary>
         [Test]
-        public void CanAddQuaternionsUsingOperator()
+        public void CanAddQuaternionsAndFloatUsingOperator()
         {
             Assert.AreEqual(new Quaternion32(1, 2, 3, 4) + new Quaternion32(1, 2, 3, 4), new Quaternion32(2, 4, 6, 8));
             Assert.AreEqual(new Quaternion32(0, 0, 0, 0) + new Quaternion32(1, 2, 3, 4), new Quaternion32(1, 2, 3, 4));
+            Assert.AreEqual(1 + new Quaternion32(1, 2, 3, 4), new Quaternion32(2, 2, 3, 4));
+            Assert.AreEqual(new Quaternion32(1, 2, 3, 4) + 1, new Quaternion32(2, 2, 3, 4));
             Assert.AreEqual(new Quaternion32(0, 0, 0, 0) + Quaternion32.Zero, Quaternion32.Zero);
             Assert.AreEqual(new Quaternion32(0, 0, 0, 0) + Quaternion32.One, Quaternion32.One);
         }
@@ -26,24 +28,24 @@
         /// Can substract quaternions using operator.
         /// </summary>
         [Test]
-        public void CanSubstractQuaternionsUsingOperator()
+        public void CanSubstractQuaternionsAndFloatUsingOperator()
         {
-            Assert.AreEqual(Quaternion32.Zero,new Quaternion32(1, 2, 3, 4) - new Quaternion32(1, 2, 3, 4));
-            Assert.AreEqual(new Quaternion32(-1, -2, -3, -4),new Quaternion32(0, 0, 0, 0) - new Quaternion32(1, 2, 3, 4));
-            Assert.AreEqual(Quaternion32.Zero,new Quaternion32(0, 0, 0, 0) - Quaternion32.Zero);
-            //Assert.AreEqual(new Quaternion32(0, 0, 0, 0) - Quaternion32.One, -Quaternion32.One);
+            Assert.AreEqual(Quaternion32.Zero, new Quaternion32(1, 2, 3, 4) - new Quaternion32(1, 2, 3, 4));
+            Assert.AreEqual(new Quaternion32(-1, -2, -3, -4), new Quaternion32(0, 0, 0, 0) - new Quaternion32(1, 2, 3, 4));
+            Assert.AreEqual(Quaternion32.Zero, new Quaternion32(0, 0, 0, 0) - Quaternion32.Zero);
+            Assert.AreEqual(new Quaternion32(0, 0, 0, 0) - Quaternion32.One, -Quaternion32.One);
+            Assert.AreEqual(1 - new Quaternion32(1, 2, 3, 4), new Quaternion32(0, 2, 3, 4));
+            Assert.AreEqual(new Quaternion32(1, 2, 3, 4) - 1, new Quaternion32(0, 2, 3, 4));
         }
 
         [Test]
-        public void CanMultiplyQuaternionsUsingOperator()
+        public void CanMultiplyQuaternionsAndFloatUsingOperator()
         {
             Assert.AreEqual(new Quaternion32(8, -9, -2, 11), new Quaternion32(3, 1, -2, 1) * new Quaternion32(2, -1, 2, 3));
+            Assert.AreEqual(new Quaternion32(3, 1, -2, 1), new Quaternion32(3, 1, -2, 1) * 1);
+            Assert.AreEqual(new Quaternion32(6, 2, -4, 2), new Quaternion32(3, 1, -2, 1) * 2);
+            Assert.AreEqual(new Quaternion32(1.5f, 0.5f, -1, 0.5f), new Quaternion32(3, 1, -2, 1) * 0.5f);
         }
 
-        [Test]
-        public void CanCalculateDotProduct()
-        {
-            Assert.AreEqual(new Quaternion32(0, -8, -4, 0),Quaternion32.DotProduct(new Quaternion32(3, 1, -2, 1), new Quaternion32(2, -1, 2, 3)));
-        }
     }
 }

--- a/src/UnitTests/QuaternionsTests/Quaternions32Tests.cs
+++ b/src/UnitTests/QuaternionsTests/Quaternions32Tests.cs
@@ -1,0 +1,49 @@
+﻿namespace MathNet.Numerics.UnitTests.QuaternionsTests
+{
+    using System.Security.Cryptography.X509Certificates;
+    using NUnit.Framework;
+    /// <summary>
+    /// Complex32 tests.
+    /// </summary>
+    /// <remarks>
+    /// Tests are based on http://web.cs.iastate.edu/~cs577/handouts/quaternion.pdf and my own calculations
+    /// </remarks>
+    [TestFixture]
+    public class Quaternions32Tests
+    {
+        /// <summary>
+        /// Can add a quaternions using operator.
+        /// </summary>
+        [Test]
+        public void CanAddQuaternionsUsingOperator()
+        {
+            Assert.AreEqual(new Quaternion32(1, 2, 3, 4) + new Quaternion32(1, 2, 3, 4), new Quaternion32(2, 4, 6, 8));
+            Assert.AreEqual(new Quaternion32(0, 0, 0, 0) + new Quaternion32(1, 2, 3, 4), new Quaternion32(1, 2, 3, 4));
+            Assert.AreEqual(new Quaternion32(0, 0, 0, 0) + Quaternion32.Zero, Quaternion32.Zero);
+            Assert.AreEqual(new Quaternion32(0, 0, 0, 0) + Quaternion32.One, Quaternion32.One);
+        }
+        /// <summary>
+        /// Can substract quaternions using operator.
+        /// </summary>
+        [Test]
+        public void CanSubstractQuaternionsUsingOperator()
+        {
+            Assert.AreEqual(Quaternion32.Zero,new Quaternion32(1, 2, 3, 4) - new Quaternion32(1, 2, 3, 4));
+            Assert.AreEqual(new Quaternion32(-1, -2, -3, -4),new Quaternion32(0, 0, 0, 0) - new Quaternion32(1, 2, 3, 4));
+            Assert.AreEqual(Quaternion32.Zero,new Quaternion32(0, 0, 0, 0) - Quaternion32.Zero);
+            //Assert.AreEqual(new Quaternion32(0, 0, 0, 0) - Quaternion32.One, -Quaternion32.One);
+        }
+
+        [Test]
+        public void CanMultiplyQuaternionsUsingOperator()
+        {
+            Assert.AreEqual(new Quaternion32(8, -9, -2, 11), new Quaternion32(3, 1, -2, 1) * new Quaternion32(2, -1, 2, 3));
+        }
+
+        [Test]
+        public void CanCalculateDotProduct()
+        {
+            Assert.AreEqual(new Quaternion32(0, -8, -4, 0),Quaternion32.DotProduct(new Quaternion32(3, 1, -2, 1), new Quaternion32(2, -1, 2, 3)));
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -65,10 +65,6 @@
     <LangVersion>5</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
@@ -418,8 +414,14 @@
     <Compile Include="UseLinearAlgebraProvider.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
     <None Include="paket.references" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <Reference Include="nunit.framework">
+      <HintPath>..\..\packages\test\NUnit\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+      <Paket>True</Paket>
+    </Reference>
+  </ItemGroup>
 </Project>

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -65,9 +65,6 @@
     <LangVersion>5</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <Private>False</Private>
-    </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -65,6 +65,13 @@
     <LangVersion>5</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
@@ -361,6 +368,7 @@
     <Compile Include="EuclidTests\IntegerTheoryTest.cs" />
     <Compile Include="LinearAlgebraTests\MatrixStorageCombinatorsTests.cs" />
     <Compile Include="LinearAlgebraTests\VectorStorageCombinatorsTests.cs" />
+    <Compile Include="QuaternionsTests\Quaternions32Tests.cs" />
     <Compile Include="Random\SystemRandomSourceTests.cs" />
     <Compile Include="RootFindingTests\BisectionTest.cs" />
     <Compile Include="PermutationTest.cs" />
@@ -413,14 +421,8 @@
     <Compile Include="UseLinearAlgebraProvider.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
     <None Include="paket.references" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <ItemGroup>
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\test\NUnit\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
-      <Paket>True</Paket>
-    </Reference>
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
[THIS PULL IS NOT FULLY READY YET]

I noticed that there is implementation of quaternions in F# : [here](https://github.com/mathnet/mathnet-numerics/pull/367)

Kjbartel said that we need C# implementation of it thus I started to implement.

Just give me one or two days to make it fully work.

Things to do :

Actual Code : 
- [ ] Rotations
- [ ] More robust division (possible overflow)
- [ ] Create more robust norm (possible overflow)
- [ ] Create quaternion from angle
- [ ] Create quaternion from matrix

--
Testing
- [ ] DotProduct
- [ ] Inversion
- [ ] Equality, operator ==
- [ ] ToString()
- [ ] Norm
- [ ] Conjugation
- [ ] operator* for floats 
- [ ] operator/

If you have any more ideas what to add just post it - I will handle it.
If you want to contribute :  [here is my git repo](https://github.com/MaLiN2223/mathnet-numerics/tree/malins)
