### PR TITLE
Fix indirect dependencies on native dlls

### DIFF
--- a/build/NativeProvider.targets
+++ b/build/NativeProvider.targets
@@ -7,9 +7,9 @@
   <ItemGroup Condition="'$(MSBuildThisFileDirectory)' != '' And HasTrailingSlash('$(MSBuildThisFileDirectory)')">
     <MathNetInteropFiles Include="$(MSBuildThisFileDirectory)**\*.dll" />
     <MathNetInteropFiles Include="$(MSBuildThisFileDirectory)**\*.so" />
-    <Content Include="@(MathNetInteropFiles)">
+    <None Include="@(MathNetInteropFiles)">
       <Link>%(RecursiveDir)%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Suppose Lib1 is a C# project which uses the NuGet package containing the native dll, and Lib2 depends on Lib1, and finally Lib3 depends on Lib2.  With the current setup, the native dlls will be copied into the output directory of both Lib1 and Lib2, but not Lib3.  Using 'None' instead of 'Content' fixes this.

I don't have a reference for this behaviour, but I have replicated it with three dummy projects to be sure.  I originally got the hint from Benoit Blanchon's comment at http://stackoverflow.com/questions/19478775/