### PR TITLE
Fixed typo in TestBfgsMinimizer.FindMinimum_BigRosenbrock_Hard()

### DIFF
--- a/src/Numerics/Optimization/BfgsMinimizer.cs
+++ b/src/Numerics/Optimization/BfgsMinimizer.cs
@@ -78,11 +78,6 @@ namespace MathNet.Numerics.Optimization
                     searchDirection = -objective.Gradient;
                     inversePseudoHessian = CreateMatrix.DenseIdentity<double>(initialGuess.Count);
                 }
-                //else if (searchDirection * objective.Gradient >= -GradientTolerance*GradientTolerance)
-                //{
-                //    searchDirection = -objective.Gradient;
-                //    inversePseudoHessian = CreateMatrix.DenseIdentity<double>(initialGuess.Count);
-                //}
 
                 previousGradient = objective.Gradient;
                 previousPoint = objective.Point;

--- a/src/UnitTests/OptimizationTests/RosenbrockFunction.cs
+++ b/src/UnitTests/OptimizationTests/RosenbrockFunction.cs
@@ -28,6 +28,14 @@ namespace MathNet.Numerics.UnitTests.OptimizationTests
             output[1, 0] = output[0, 1];
             return output;
         }
+
+        public static Vector<double> Minimum
+        {
+            get
+            {
+                return new DenseVector(new double[] { 1, 1 });
+            }
+        }
     }
 
     public static class BigRosenbrockFunction
@@ -45,6 +53,14 @@ namespace MathNet.Numerics.UnitTests.OptimizationTests
         public static Matrix<double> Hessian(Vector<double> input)
         {
             return 100.0 * RosenbrockFunction.Hessian(input / 100.0);
+        }
+
+        public static Vector<double> Minimum
+        {
+            get
+            {
+                return new DenseVector(new double[] { 100, 100 });
+            }
         }
     }
 }

--- a/src/UnitTests/OptimizationTests/TestBfgsMinimizer.cs
+++ b/src/UnitTests/OptimizationTests/TestBfgsMinimizer.cs
@@ -15,8 +15,8 @@ namespace MathNet.Numerics.UnitTests.OptimizationTests
             var solver = new BfgsMinimizer(1e-5, 1e-5, 1000);
             var result = solver.FindMinimum(obj, new DenseVector(new[] { 1.2, 1.2 }));
 
-            Assert.That(Math.Abs(result.MinimizingPoint[0] - 1.0), Is.LessThan(1e-3));
-            Assert.That(Math.Abs(result.MinimizingPoint[1] - 1.0), Is.LessThan(1e-3));
+            Assert.That(Math.Abs(result.MinimizingPoint[0] - RosenbrockFunction.Minimum[0]), Is.LessThan(1e-3));
+            Assert.That(Math.Abs(result.MinimizingPoint[1] - RosenbrockFunction.Minimum[1]), Is.LessThan(1e-3));
         }
 
         [Test]
@@ -26,8 +26,8 @@ namespace MathNet.Numerics.UnitTests.OptimizationTests
             var solver = new BfgsMinimizer(1e-5, 1e-5, 1000);
             var result = solver.FindMinimum(obj, new DenseVector(new[] { -1.2, 1.0 }));
 
-            Assert.That(Math.Abs(result.MinimizingPoint[0] - 1.0), Is.LessThan(1e-3));
-            Assert.That(Math.Abs(result.MinimizingPoint[1] - 1.0), Is.LessThan(1e-3));
+            Assert.That(Math.Abs(result.MinimizingPoint[0] - RosenbrockFunction.Minimum[0]), Is.LessThan(1e-3));
+            Assert.That(Math.Abs(result.MinimizingPoint[1] - RosenbrockFunction.Minimum[1]), Is.LessThan(1e-3));
         }
 
         [Test]
@@ -37,8 +37,8 @@ namespace MathNet.Numerics.UnitTests.OptimizationTests
             var solver = new BfgsMinimizer(1e-5, 1e-5, 1000);
             var result = solver.FindMinimum(obj, new DenseVector(new[] { -0.9, -0.5 }));
 
-            Assert.That(Math.Abs(result.MinimizingPoint[0] - 1.0), Is.LessThan(1e-3));
-            Assert.That(Math.Abs(result.MinimizingPoint[1] - 1.0), Is.LessThan(1e-3));
+            Assert.That(Math.Abs(result.MinimizingPoint[0] - RosenbrockFunction.Minimum[0]), Is.LessThan(1e-3));
+            Assert.That(Math.Abs(result.MinimizingPoint[1] - RosenbrockFunction.Minimum[1]), Is.LessThan(1e-3));
         }
 
 		[Test]
@@ -48,8 +48,8 @@ namespace MathNet.Numerics.UnitTests.OptimizationTests
 			var solver = new BfgsMinimizer(1e-10, 1e-5, 1000);
 			var result = solver.FindMinimum(obj, new DenseVector(new[] { 1.2*100.0, 1.2*100.0 }));
 
-			Assert.That(Math.Abs(result.MinimizingPoint[0] - 100.0), Is.LessThan(1e-3));
-			Assert.That(Math.Abs(result.MinimizingPoint[1] - 100.0), Is.LessThan(1e-3));
+			Assert.That(Math.Abs(result.MinimizingPoint[0] - BigRosenbrockFunction.Minimum[0]), Is.LessThan(1e-3));
+			Assert.That(Math.Abs(result.MinimizingPoint[1] - BigRosenbrockFunction.Minimum[1]), Is.LessThan(1e-3));
 		}
 
 		[Test]
@@ -59,8 +59,8 @@ namespace MathNet.Numerics.UnitTests.OptimizationTests
 			var solver = new BfgsMinimizer(1e-5, 1e-5, 1000);
 			var result = solver.FindMinimum(obj, new DenseVector(new[] { -1.2*100.0, 1.0*100.0 }));
 
-			Assert.That(Math.Abs(result.MinimizingPoint[0] - 1.0), Is.LessThan(1e-3));
-			Assert.That(Math.Abs(result.MinimizingPoint[1] - 1.0), Is.LessThan(1e-3));
+			Assert.That(Math.Abs(result.MinimizingPoint[0] - BigRosenbrockFunction.Minimum[0]), Is.LessThan(1e-3));
+			Assert.That(Math.Abs(result.MinimizingPoint[1] - BigRosenbrockFunction.Minimum[1]), Is.LessThan(1e-3));
 		}
 
 		[Test]
@@ -70,8 +70,8 @@ namespace MathNet.Numerics.UnitTests.OptimizationTests
 			var solver = new BfgsMinimizer(1e-5, 1e-5, 1000);
 			var result = solver.FindMinimum(obj, new DenseVector(new[] { -0.9*100.0, -0.5*100.0 }));
 
-			Assert.That(Math.Abs(result.MinimizingPoint[0] - 100.0), Is.LessThan(1e-3));
-			Assert.That(Math.Abs(result.MinimizingPoint[1] - 100.0), Is.LessThan(1e-3));
+			Assert.That(Math.Abs(result.MinimizingPoint[0] - BigRosenbrockFunction.Minimum[0]), Is.LessThan(1e-3));
+			Assert.That(Math.Abs(result.MinimizingPoint[1] - BigRosenbrockFunction.Minimum[1]), Is.LessThan(1e-3));
 		}
     }
 }


### PR DESCRIPTION
Fixed typo in TestBfgsMinimizer.FindMinimum_BigRosenbrock_Hard() and added static property to avoid future similar typos