### PR TITLE
fixed generation of ChiSquared Samples

### DIFF
--- a/src/Numerics/Distributions/ChiSquared.cs
+++ b/src/Numerics/Distributions/ChiSquared.cs
@@ -300,7 +300,7 @@ namespace MathNet.Numerics.Distributions
                             sum += standard[k + j]*standard[k + j];
                         }
 
-                        values[i] = Math.Sqrt(sum);
+                        values[i] = sum;
                     }
                 });
                 return;


### PR DESCRIPTION
I noticed a bug in the generation of ChiSquared samples. Probably left from copy-pasting code from Chi.cs