### PR TITLE
R squared

### DIFF
--- a/src/Numerics/GoodnessOfFit.cs
+++ b/src/Numerics/GoodnessOfFit.cs
@@ -48,13 +48,13 @@ namespace MathNet.Numerics
         }
 
         /// <summary>
-        /// Calculated the R-Squared value, also known as coefficient of determination,
-        /// given modelled and observed values
+        /// Calculates the R-Squared value, also known as coefficient of determination,
+        /// given some modelled and observed values.
         /// </summary>
-        /// <param name="modelledValues">The values expected from the modelled</param>
-        /// <param name="observedValues">The actual data set values obtained</param>
-        /// <returns>Squared Person product-momentum correlation coefficient.</returns>
-        public static double CoefficentOfDetermination(IEnumerable<double> modelledValues, IEnumerable<double> observedValues)
+        /// <param name="modelledValues">The values expected from the model.</param>
+        /// <param name="observedValues">The actual values obtained.</param>
+        /// <returns>Coefficient of determination.</returns>
+        public static double CoefficientOfDetermination(IEnumerable<double> modelledValues, IEnumerable<double> observedValues)
         {
             var y = observedValues;
             var f = modelledValues;

--- a/src/Numerics/GoodnessOfFit.cs
+++ b/src/Numerics/GoodnessOfFit.cs
@@ -71,7 +71,7 @@ namespace MathNet.Numerics
             using (IEnumerator<double> ieF = f.GetEnumerator()) {
                 while (ieY.MoveNext()) {
                     if (!ieF.MoveNext()) {
-                        throw new ArgumentOutOfRangeException("dataB", Resources.ArgumentArraysSameLength);
+                        throw new ArgumentOutOfRangeException("modelledValues", Resources.ArgumentArraysSameLength);
                     }
 
                     double currentY = ieY.Current;
@@ -86,7 +86,7 @@ namespace MathNet.Numerics
                 }
 
                 if (ieF.MoveNext()) {
-                    throw new ArgumentOutOfRangeException("dataA", Resources.ArgumentArraysSameLength);
+                    throw new ArgumentOutOfRangeException("observedValues", Resources.ArgumentArraysSameLength);
                 }
             }
             return 1 - ssRes/ssTot;

--- a/src/Numerics/GoodnessOfFit.cs
+++ b/src/Numerics/GoodnessOfFit.cs
@@ -65,9 +65,12 @@ namespace MathNet.Numerics
             double ssRes = 0;
 
             using (IEnumerator<double> ieY = y.GetEnumerator())
-            using (IEnumerator<double> ieF = f.GetEnumerator()) {
-                while (ieY.MoveNext()) {
-                    if (!ieF.MoveNext()) {
+            using (IEnumerator<double> ieF = f.GetEnumerator())
+            {
+                while (ieY.MoveNext())
+                {
+                    if (!ieF.MoveNext())
+                    {
                         throw new ArgumentOutOfRangeException("modelledValues", Resources.ArgumentArraysSameLength);
                     }
 
@@ -96,7 +99,8 @@ namespace MathNet.Numerics
                     ssRes += (currentY - currentF)*(currentY-currentF);
                 }
 
-                if (ieF.MoveNext()) {
+                if (ieF.MoveNext())
+                {
                     throw new ArgumentOutOfRangeException("observedValues", Resources.ArgumentArraysSameLength);
                 }
             }

--- a/src/Numerics/GoodnessOfFit.cs
+++ b/src/Numerics/GoodnessOfFit.cs
@@ -27,6 +27,8 @@
 
 using System.Collections.Generic;
 using MathNet.Numerics.Statistics;
+using System;
+using MathNet.Numerics.Properties;
 
 namespace MathNet.Numerics
 {
@@ -43,6 +45,51 @@ namespace MathNet.Numerics
         {
             var corr = Correlation.Pearson(modelledValues, observedValues);
             return corr * corr;
+        }
+
+        /// <summary>
+        /// Calculated the R-Squared value, also known as coefficient of determination,
+        /// given modelled and observed values
+        /// </summary>
+        /// <param name="modelledValues">The values expected from the modelled</param>
+        /// <param name="observedValues">The actual data set values obtained</param>
+        /// <returns>Squared Person product-momentum correlation coefficient.</returns>
+        public static double CoefficentOfDetermination(IEnumerable<double> modelledValues, IEnumerable<double> observedValues)
+        {
+            var y = observedValues;
+            var f = modelledValues;
+            int n = 0;
+
+            double meanY = 0;
+            double ssTot = 0;
+            double ssRes = 0;
+
+            // WARNING: do not try to "optimize" by summing up products instead of using differences.
+            // It would indeed be faster, but numerically much less robust if large mean + low variance.
+
+            using (IEnumerator<double> ieY = y.GetEnumerator())
+            using (IEnumerator<double> ieF = f.GetEnumerator()) {
+                while (ieY.MoveNext()) {
+                    if (!ieF.MoveNext()) {
+                        throw new ArgumentOutOfRangeException("dataB", Resources.ArgumentArraysSameLength);
+                    }
+
+                    double currentY = ieY.Current;
+                    double currentF = ieF.Current;
+
+                    double deltaY = currentY - meanY;
+                    double scaleDeltaY = deltaY/++n;
+
+                    meanY += scaleDeltaY;
+                    ssTot += scaleDeltaY*deltaY*(n - 1);
+                    ssRes += (currentY - currentF)*(currentY-currentF);
+                }
+
+                if (ieF.MoveNext()) {
+                    throw new ArgumentOutOfRangeException("dataA", Resources.ArgumentArraysSameLength);
+                }
+            }
+            return 1 - ssRes/ssTot;
         }
 
         /// <summary>

--- a/src/UnitTests/GoodnessOfFit/RSquaredTest.cs
+++ b/src/UnitTests/GoodnessOfFit/RSquaredTest.cs
@@ -58,7 +58,7 @@ namespace MathNet.Numerics.UnitTests.GoodnessOfFit
         public void CoefficentOfDetermination_OfDataWithItself_EqualsOne()
         {
             var data = Generate.LinearRange(1, 100);
-            AssertHelpers.AlmostEqual(Numerics.GoodnessOfFit.CoefficentOfDetermination(data, data), 1.0, 14);
+            AssertHelpers.AlmostEqual(Numerics.GoodnessOfFit.CoefficientOfDetermination(data, data), 1.0, 14);
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace MathNet.Numerics.UnitTests.GoodnessOfFit
             // actual values and comparison
             var data = Generate.LinearRange(1, n);
             var model = Generate.LinearRange(1+offset, n+offset);
-            double R2Calc = Numerics.GoodnessOfFit.CoefficentOfDetermination(model, data);
+            double R2Calc = Numerics.GoodnessOfFit.CoefficientOfDetermination(model, data);
             Assert.That(R2Calc, Is.Not.EqualTo(1));
         }
 
@@ -96,7 +96,7 @@ namespace MathNet.Numerics.UnitTests.GoodnessOfFit
             // actual values and comparison
             var data = Generate.LinearRange(1, n);
             var model = Generate.LinearRange(1+offset, n+offset);
-            double R2Calc = Numerics.GoodnessOfFit.CoefficentOfDetermination(model, data);
+            double R2Calc = Numerics.GoodnessOfFit.CoefficientOfDetermination(model, data);
             AssertHelpers.AlmostEqual(R2Calc, R2, 14);
         }
 

--- a/src/UnitTests/GoodnessOfFit/RSquaredTest.cs
+++ b/src/UnitTests/GoodnessOfFit/RSquaredTest.cs
@@ -51,6 +51,55 @@ namespace MathNet.Numerics.UnitTests.GoodnessOfFit
             Assert.That(Numerics.GoodnessOfFit.RSquared(data, data), Is.EqualTo(1));
         }
 
+        /// <summary>
+        /// Test the R-squared value of values with itself
+        /// </summary>
+        [Test]
+        public void CoefficentOfDetermination_OfDataWithItself_EqualsOne()
+        {
+            var data = Generate.LinearRange(1, 100);
+            AssertHelpers.AlmostEqual(Numerics.GoodnessOfFit.CoefficentOfDetermination(data, data), 1.0, 14);
+        }
+
+        /// <summary>
+        /// Test the R-squared value of values with correlated values
+        /// </summary>
+        [Test]
+        public void CoefficentOfDetermination_OfCorrelatedData_DoesNotEqualOne()
+        {
+            // parameters
+            int n = 100;
+            int offset = 1;
+
+            // actual values and comparison
+            var data = Generate.LinearRange(1, n);
+            var model = Generate.LinearRange(1+offset, n+offset);
+            double R2Calc = Numerics.GoodnessOfFit.CoefficentOfDetermination(model, data);
+            Assert.That(R2Calc, Is.Not.EqualTo(1));
+        }
+
+        /// <summary>
+        /// Test the R-squared value of values with correlated values
+        /// </summary>
+        [Test]
+        public void CoefficentOfDetermination_OfCorrelatedData_KnownOutput()
+        {
+            // parameters
+            int n = 100;
+            int offset = 1;
+
+            // theoretical values
+            double ssTot = (n*(n-1)*(n+1))/12.0;
+            double ssRes = n*offset*offset;
+            double R2 = 1-ssRes/ssTot;
+
+            // actual values and comparison
+            var data = Generate.LinearRange(1, n);
+            var model = Generate.LinearRange(1+offset, n+offset);
+            double R2Calc = Numerics.GoodnessOfFit.CoefficentOfDetermination(model, data);
+            AssertHelpers.AlmostEqual(R2Calc, R2, 14);
+        }
+
         [Test]
         public void WhenGivenTwoDatasetsOfDifferentSizeThenThrowsArgumentException()
         {


### PR DESCRIPTION
I added a method "CoefficentOfDetermination" which calculates the R^2 value.  Currently the method "RSquared" calculates r^2 (the square of the correlation between the model and data), now r^2 is equal to R^2 when the model was created via least squares linear regression.  However in other cases r^2 is not equal to R^2.  

I was not sure whether to replace the old implementation of "RSquared" or write a new method. According to [Wikipedia](https://en.wikipedia.org/wiki/Coefficient_of_determination#As_squared_correlation_coefficient) some people use r^2 to determine how good a least squares line fit would have been; thus rewriting "RSquared" might be a breaking change; thus I opted, for now, to write a new method (although maybe we should add a "rSquared" method and mark "RSquared" as obsolete(??)).

I also added three unit tests.
