### PR TITLE
Fix for Issue #427

### DIFF
--- a/src/Numerics/Random/RandomSource.cs
+++ b/src/Numerics/Random/RandomSource.cs
@@ -455,6 +455,12 @@ namespace MathNet.Numerics.Random
         /// </summary>
         protected virtual int DoSampleInt32WithNBits(int bitCount)
         {
+			// Fast case: Only 0 is allowed to be returned
+            // No random call is needed
+            if (bitCount == 0)
+            {
+                return 0;
+            }
             var bytes = new byte[4];
             DoSampleBytes(bytes);
 

--- a/src/Numerics/Random/RandomSource.cs
+++ b/src/Numerics/Random/RandomSource.cs
@@ -472,6 +472,12 @@ namespace MathNet.Numerics.Random
         /// </summary>
         protected virtual long DoSampleInt64WithNBits(int bitCount)
         {
+			// Fast case: Only 0 is allowed to be returned
+            // No random call is needed
+            if (bitCount == 0)
+            {
+                return 0;
+            }
             var bytes = new byte[8];
             DoSampleBytes(bytes);
 
@@ -489,6 +495,13 @@ namespace MathNet.Numerics.Random
         /// <param name="maxExclusive">The exclusive upper bound of the random number returned.</param>
         protected virtual int DoSampleInteger(int maxExclusive)
         {
+			// Fast case: Only a single number is allowed to be returned
+            // No random call is needed
+            if (maxExclusive == 1)
+            {
+                return 0;
+            }
+			
             // non-biased implementation
             // (biased: return (int)(DoSample() * maxExclusive);)
 

--- a/src/UnitTests/Random/RandomTests.cs
+++ b/src/UnitTests/Random/RandomTests.cs
@@ -84,6 +84,29 @@ namespace MathNet.Numerics.UnitTests.Random
                 disposable.Dispose();
             }
         }
+		
+		/// <summary>
+        ///     Next() result is in boundaries.
+        /// </summary>
+        [Test]
+        public void Boundaries()
+        {
+            var random = (System.Random)Activator.CreateInstance(_randomType, new object[] { false });
+
+            for (var i = 1; i < N; i++)
+            {
+                var j = N;
+                var next = random.Next(i, j);
+                Assert.IsTrue(next >= i, string.Format("Value {0} is smaller than lower bound {1}", next, i));
+                Assert.IsTrue(next < j, string.Format("Value {0} is larger or equal to upper bound {1}", next, j));
+            }
+
+            var disposable = random as IDisposable;
+            if (disposable != null)
+            {
+                disposable.Dispose();
+            }
+        }
 
         [Test]
         public void Reproducible()


### PR DESCRIPTION
I added two special cases:
* when 0 bits should be sampled, alsways return 0
* when an int should be sampled with an exclusive maximum of 1, always return 0

This should fix Issue #427 .
I also added a new test, if the boundaries are respected when calling Next(). I'm not  completely sure it's in the right place though.