### PR TITLE
Added T-Statistic calculation for linear model

### DIFF
--- a/src/UnitTests/GoodnessOfFit/TStatisticTest.cs
+++ b/src/UnitTests/GoodnessOfFit/TStatisticTest.cs
@@ -1,0 +1,90 @@
+﻿// <copyright file="TStatisticTest.cs" company="Math.NET">
+// Math.NET Numerics, part of the Math.NET Project
+// http://numerics.mathdotnet.com
+// http://github.com/mathnet/mathnet-numerics
+//
+// Copyright (c) 2009-2013 Math.NET
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+
+namespace MathNet.Numerics.UnitTests.GoodnessOfFit
+{
+    [TestFixture, Category("Regression")]
+    public class TStatisticTest
+    {
+        [Test]
+        public void ComputesTStatisticForSlopeCoefficient()
+        {
+            var tstats = GetTStatistics();
+            Assert.AreEqual(37.4058, tstats.Item2, 1e-3);
+        }
+
+        [Test]
+        public void ComputesTStatisticForInterceptTerm()
+        {
+            var tstats = GetTStatistics();
+            Assert.AreEqual(4.1752, tstats.Item1, 1e-3);
+        }
+
+        [Test]
+        public void TStatisticsShouldThrowIfSampleSizeIsSmallerThanDegreesOfFreedom()
+        {
+            var independent = new[] {1.0 };
+            var dependent = new[] { 1.0 };
+            var predictions = new[] { 1.0 };
+            var slope = 1.0;
+            var intercept = 1.0;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => Numerics.GoodnessOfFit.TStatistics(slope, intercept, independent, dependent, predictions));
+        }
+
+        private static double[] xes()
+        {
+            return new[] { 50, 53, 54, 55, 56, 59, 62, 65, 67, 71, 72, 74, 75, 76, 79, 80, 82, 85, 87, 90, 93, 94, 95, 97, 100 }
+                .Select(Convert.ToDouble)
+                .ToArray();
+        }
+
+        private static double[] ys()
+        {
+            return new[] { 122, 118, 128, 121, 125, 136, 144, 142, 149, 161, 167, 168, 162, 171, 175, 182, 180, 183, 188, 200, 194, 206, 207, 210, 219 }
+                .Select(Convert.ToDouble)
+                .ToArray();
+        }
+
+        private Tuple<double, double> GetTStatistics()
+        {
+            var line = Fit.Line(xes(), ys());
+            var intercept = line.Item1;
+            var slope = line.Item2;
+            var predictions = xes().Select(x => intercept + x * slope).ToArray();
+            var tstats = Numerics.GoodnessOfFit.TStatistics(slope, intercept, xes(), ys(), predictions);
+            return tstats;
+        }
+    }
+}
+

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -143,6 +143,7 @@
     <Compile Include="GenerateTests.cs" />
     <Compile Include="GoodnessOfFit\RSquaredTest.cs" />
     <Compile Include="GoodnessOfFit\StandardErrorTest.cs" />
+    <Compile Include="GoodnessOfFit\TStatisticTest.cs" />
     <Compile Include="Providers\FourierTransform\FourierTransformProviderTests.cs" />
     <Compile Include="IntegralTransformsTests\FourierTest.cs" />
     <Compile Include="IntegralTransformsTests\HartleyTest.cs" />


### PR DESCRIPTION
Using [this article](http://reliawiki.org/index.php/Simple_Linear_Regression_Analysis#Simple_Linear_Regression_Analysis) for inspiration (scroll down to _Hypothesis Tests in Simple Linear Regression - t Tests_).

Main Ideas:
A) I calculated the T-Statistic on a per-parameter basis (slope vs. y-intercept), which makes me realize that I also probably should have done so as well for the Standard Error Calculation that I recently committed.  Thoughts?

B) I've again stuck with IEnumerable<double>s for the method arguments for consistency, but upon further thought I might like to refactor all methods in this class to use double[]s instead.  The nature of these computations is such that the entire sequences are iterated every time, with no potential for deferred execution, so it seems that using arrays would create more "honest" method signatures, and would provide some greatly simplified iteration as well as preemptive length checking, etc.  Also as I understand it, a **for** loop over an array might perform slightly better over very large data sets, though I have not tested this myself.

C) Biggest thought:  The method signature for calculating this T-Statistic seems a bit gnarly, and seems to require quite a bit more knowledge on the part of the user than perhaps should be necessary.  **Would you perhaps like me to forgo the code in this pull request entirely in favor of a "linear model object"-type solution as can be found in other numerical analysis packages?**

One example of a "linear model object" strategy can be seen in the **lm** model in R.  You provide your inputs to the constructor/creation function of the **lm** object, and the result is an object that contains information as follows:
![image](https://cloud.githubusercontent.com/assets/1380588/21671250/f97d557c-d2ce-11e6-8b8c-90e75adcb5d5.png)
Additionally, this model object contains behavioral knowledge to predict further output values using the parameters it fitted during its construction, provided that further inputs are provided to its prediction function in the same format as the initial training data.

This seems like it would represent a bit of a departure from the current style of functionality provided by this project, but as it stands, to get a T-Statistic the user has to understand 3 separate intricate and connected steps: fitting the line, using the fitted line parameters to create new predictions, and then passing all of the information from steps 1 & 2 into the T-Statistic function, which I fear might be a similar situation when I go on to add the F-Statistic calculation, P-value, etc.

Additionally, named object properties can improve the user experience and code readability, as compared to retrieving .Item1, .Item2, etc. from a Tuple.

I'd be interested to hear what your thoughts are.
