### PR TITLE
Added implicit conversions from Matrix<T> to Matrix<Complex> and from Vector<T> to Vector<Complex>, added matrix division

### DIFF
--- a/src/Numerics/LinearAlgebra/Matrix.Conversions.cs
+++ b/src/Numerics/LinearAlgebra/Matrix.Conversions.cs
@@ -1,0 +1,65 @@
+﻿// <copyright file="Matrix.Conversions.cs" company="Math.NET">
+// Math.NET Numerics, part of the Math.NET Project
+// http://numerics.mathdotnet.com
+// http://github.com/mathnet/mathnet-numerics
+//
+// Copyright (c) 2009-2017 Math.NET
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace MathNet.Numerics.LinearAlgebra
+{
+#if NOSYSNUMERICS
+    using Complex64 = Numerics.Complex;
+#else
+    using Complex64 = System.Numerics.Complex;
+#endif
+    /// <summary>
+    /// Defines the base class for <c>Matrix</c> classes.
+    /// </summary>
+    public abstract partial class Matrix<T>
+    {
+        /// <summary>
+        /// Implicitly converts a matrix to double precision complex numbers.
+        /// </summary>
+        public static implicit operator Matrix<Complex64>(Matrix<T> matrix)
+        {
+            var matrixDouble = matrix as Matrix<double>;
+            if (matrixDouble != null)
+                return matrixDouble.ToComplex();
+
+            var matrixFloat = matrix as Matrix<float>;
+            if (matrixFloat != null)
+                return matrixFloat.ToComplex();
+
+            var matrixComplex32 = matrix as Matrix<Numerics.Complex32>;
+            if (matrixComplex32 != null)
+                return matrixComplex32.ToComplex();
+
+            return matrix.Map(x => new Complex64(Convert.ToDouble(x), 0), Zeros.AllowSkip);
+        }
+    }
+}

--- a/src/Numerics/LinearAlgebra/Matrix.Operators.cs
+++ b/src/Numerics/LinearAlgebra/Matrix.Operators.cs
@@ -238,6 +238,17 @@ namespace MathNet.Numerics.LinearAlgebra
         }
 
         /// <summary>
+        /// Divides a matrix with a matrix.
+        /// </summary>
+        /// <param name="dividend">The matrix to divide.</param>
+        /// <param name="divisor">The matrix divisor.</param>
+        /// <returns>The result of the division.</returns>
+        public static Matrix<T> operator /(Matrix<T> dividend, Matrix<T> divisor)
+        {
+            return dividend.Multiply(divisor.Inverse());
+        }
+
+        /// <summary>
         /// Computes the pointwise remainder (% operator), where the result has the sign of the dividend,
         /// of each element of the matrix of the given divisor.
         /// </summary>

--- a/src/Numerics/LinearAlgebra/MatrixExtensions.cs
+++ b/src/Numerics/LinearAlgebra/MatrixExtensions.cs
@@ -80,6 +80,14 @@ namespace MathNet.Numerics.LinearAlgebra
         /// <summary>
         /// Gets a double precision complex matrix with the real parts from the given matrix.
         /// </summary>
+        public static Matrix<Complex64> ToComplex(this Matrix<float> matrix)
+        {
+            return matrix.Map(x => new Complex64(x, 0d), Zeros.AllowSkip);
+        }
+
+        /// <summary>
+        /// Gets a double precision complex matrix with the real parts from the given matrix.
+        /// </summary>
         public static Matrix<Complex64> ToComplex(this Matrix<double> matrix)
         {
             return matrix.Map(x => new Complex64(x, 0d), Zeros.AllowSkip);

--- a/src/Numerics/LinearAlgebra/Vector.Conversions.cs
+++ b/src/Numerics/LinearAlgebra/Vector.Conversions.cs
@@ -1,0 +1,62 @@
+﻿// <copyright file="Vector.Conversions.cs" company="Math.NET">
+// Math.NET Numerics, part of the Math.NET Project
+// http://numerics.mathdotnet.com
+// http://github.com/mathnet/mathnet-numerics
+//
+// Copyright (c) 2009-2017 Math.NET
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace MathNet.Numerics.LinearAlgebra
+{
+#if NOSYSNUMERICS
+    using Complex64 = Numerics.Complex;
+#else
+    using Complex64 = System.Numerics.Complex;
+#endif
+    public abstract partial class Vector<T>
+    {
+        /// <summary>
+        /// Implicitly converts a matrix to double precision complex numbers.
+        /// </summary>
+        public static implicit operator Vector<Complex64>(Vector<T> vector)
+        {
+            var vectorDouble = vector as Vector<double>;
+            if (vectorDouble != null)
+                return vectorDouble.ToComplex();
+
+            var vectorFloat = vector as Vector<float>;
+            if (vectorFloat != null)
+                return vectorFloat.ToComplex();
+
+            var vectorComplex32 = vector as Vector<Numerics.Complex32>;
+            if (vectorComplex32 != null)
+                return vectorComplex32.ToComplex();
+
+            return vector.Map(x => new Complex64(Convert.ToDouble(x), 0), Zeros.AllowSkip);
+        }
+    }
+}

--- a/src/Numerics/LinearAlgebra/VectorExtensions.cs
+++ b/src/Numerics/LinearAlgebra/VectorExtensions.cs
@@ -80,6 +80,14 @@ namespace MathNet.Numerics.LinearAlgebra
         /// <summary>
         /// Gets a double precision complex vector with the real parts from the given vector.
         /// </summary>
+        public static Vector<Complex64> ToComplex(this Vector<float> vector)
+        {
+            return vector.Map(x => new Complex64(x, 0d), Zeros.AllowSkip);
+        }
+
+        /// <summary>
+        /// Gets a double precision complex vector with the real parts from the given vector.
+        /// </summary>
         public static Vector<Complex64> ToComplex(this Vector<double> vector)
         {
             return vector.Map(x => new Complex64(x, 0d), Zeros.AllowSkip);

--- a/src/Numerics/Numerics.csproj
+++ b/src/Numerics/Numerics.csproj
@@ -107,10 +107,12 @@
     <Compile Include="Interpolation\StepInterpolation.cs" />
     <Compile Include="Interpolation\TransformedInterpolation.cs" />
     <Compile Include="LinearAlgebra\CreateMatrix.cs" />
+    <Compile Include="LinearAlgebra\Matrix.Conversions.cs" />
     <Compile Include="LinearAlgebra\Options.cs" />
     <Compile Include="LinearAlgebra\Solvers\DelegateStopCriterion.cs" />
     <Compile Include="LinearAlgebra\CreateVector.cs" />
     <Compile Include="LinearAlgebra\MatrixExtensions.cs" />
+    <Compile Include="LinearAlgebra\Vector.Conversions.cs" />
     <Compile Include="LinearAlgebra\VectorExtensions.cs" />
     <Compile Include="LinearRegression\Options.cs" />
     <Compile Include="OdeSolvers\AdamsBashforth.cs" />

--- a/src/UnitTests/LinearAlgebraTests/ImplicitConversionsTests.cs
+++ b/src/UnitTests/LinearAlgebraTests/ImplicitConversionsTests.cs
@@ -1,0 +1,135 @@
+// <copyright file="ImplicitConversionsTests.cs" company="Math.NET">
+// Math.NET Numerics, part of the Math.NET Project
+// http://numerics.mathdotnet.com
+// http://github.com/mathnet/mathnet-numerics
+//
+// Copyright (c) 2009-2017 Math.NET
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+
+using MathNet.Numerics.LinearAlgebra;
+using NUnit.Framework;
+
+namespace MathNet.Numerics.UnitTests.LinearAlgebraTests
+{
+#if NOSYSNUMERICS
+    using Complex64 = Numerics.Complex;
+#else
+    using Complex64 = System.Numerics.Complex;
+#endif
+    [TestFixture]
+    public class ImplicitConversionsTests
+    {
+        private const int Size = 2;
+
+        [Test]
+        public void DoubleMatrixMultipliedByComplexMatrixIsComplexMatrix()
+        {
+            var realMatrix = Matrix<double>.Build.Dense(Size, Size);
+            var complexMatrix = Matrix<Complex64>.Build.Dense(Size, Size);
+
+            var result = realMatrix*complexMatrix;
+
+            Assert.IsInstanceOf<Matrix<Complex64>>(result);
+        }
+
+        [Test]
+        public void FloatMatrixMultipliedByComplexMatrixIsComplexMatrix()
+        {
+            var floatMatrix = Matrix<float>.Build.Dense(Size, Size);
+            var complexMatrix = Matrix<Complex64>.Build.Dense(Size, Size);
+
+            var result = floatMatrix*complexMatrix;
+
+            Assert.IsInstanceOf<Matrix<Complex64>>(result);
+        }
+
+        [Test]
+        public void Complex32MatrixMultipliedByComplexMatrixIsComplexMatrix()
+        {
+            var complex32Matrix = Matrix<Numerics.Complex32>.Build.Dense(Size, Size);
+            var complexMatrix = Matrix<Complex64>.Build.Dense(Size, Size);
+
+            var result = complex32Matrix*complexMatrix;
+
+            Assert.IsInstanceOf<Matrix<Complex64>>(result);
+        }
+
+        [Test]
+        [Ignore("Doesn't work and doesn't compile because of missing implicit conversion from Matrix<float> to Matrix<double>")]
+        public void FloatMatrixMultipliedByDoubleMatrixIsDoubleMatrix()
+        {
+            var floatMatrix = Matrix<float>.Build.Dense(Size, Size);
+            var doubleMatrix = Matrix<double>.Build.Dense(Size, Size);
+
+            var result = 1;//floatMatrix*doubleMatrix;
+
+            Assert.IsInstanceOf<Matrix<double>>(result);
+        }
+
+        [Test]
+        public void DoubleVectorPlusComplexVectorIsComplexVector()
+        {
+            var realVector = Vector<double>.Build.Dense(Size, Size);
+            var complexVector = Vector<Complex64>.Build.Dense(Size, Size);
+
+            var result = realVector + complexVector;
+
+            Assert.IsInstanceOf<Vector<Complex64>>(result);
+        }
+
+        [Test]
+        public void FloatVectorPlusComplexVectorIsComplexVector()
+        {
+            var floatVector = Vector<float>.Build.Dense(Size, Size);
+            var complexVector = Vector<Complex64>.Build.Dense(Size, Size);
+
+            var result = floatVector + complexVector;
+
+            Assert.IsInstanceOf<Vector<Complex64>>(result);
+        }
+
+        [Test]
+        public void Complex32VectorPlusComplexVectorIsComplexVector()
+        {
+            var complex32Vector = Vector<Numerics.Complex32>.Build.Dense(Size, Size);
+            var complexVector = Vector<Complex64>.Build.Dense(Size, Size);
+
+            var result = complex32Vector + complexVector;
+
+            Assert.IsInstanceOf<Vector<Complex64>>(result);
+        }
+
+        [Test]
+        [Ignore("Doesn't work and doesn't compile because of missing implicit conversion from Vector<float> to Vector<double>")]
+        public void FloatVectorPlusDoubleVectorIsDoubleVector()
+        {
+            var floatVector = Vector<float>.Build.Dense(Size, Size);
+            var doubleVector = Vector<double>.Build.Dense(Size, Size);
+
+            var result = 1;//floatVector+doubleVector;
+
+            Assert.IsInstanceOf<Vector<double>>(result);
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -143,6 +143,7 @@
     <Compile Include="GenerateTests.cs" />
     <Compile Include="GoodnessOfFit\RSquaredTest.cs" />
     <Compile Include="GoodnessOfFit\StandardErrorTest.cs" />
+    <Compile Include="LinearAlgebraTests\ImplicitConversionsTests.cs" />
     <Compile Include="Providers\FourierTransform\FourierTransformProviderTests.cs" />
     <Compile Include="IntegralTransformsTests\FourierTest.cs" />
     <Compile Include="IntegralTransformsTests\HartleyTest.cs" />


### PR DESCRIPTION
Regarding issue #304, I don't know if it is good enough but this is as far as I got. It does not resolve issues related to Matrix<float> to Matrix<double> conversions thought. I had some disscusion about it here:
http://stackoverflow.com/questions/41795162/implicit-conversion-for-generic-class-restricted-only-to-some-types
and it seems like an impossible task to do it in base type (Matrix<T>).

Regarding matrix division it's just one operator added, not a big deal.