### PR TITLE
Added method 'Factorize' to 'Cholesky' base class

### DIFF
--- a/src/Numerics/LinearAlgebra/Complex/Factorization/DenseCholesky.cs
+++ b/src/Numerics/LinearAlgebra/Complex/Factorization/DenseCholesky.cs
@@ -154,5 +154,40 @@ namespace MathNet.Numerics.LinearAlgebra.Complex.Factorization
             var dfactor = (DenseMatrix) Factor;
             Control.LinearAlgebraProvider.CholeskySolveFactored(dfactor.Values, dfactor.RowCount, dresult.Values, 1);
         }
+
+        /// <summary>
+        /// Calculates the Cholesky factorization of the input matrix.
+        /// </summary>
+        /// <param name="matrix">The matrix to be factorized<see cref="Matrix{T}"/>.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="matrix"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not a square matrix.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not positive definite.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If <paramref name="matrix"/> does not have the same dimensions as the existing factor.</exception>
+        public override void Factorize(Matrix<Complex> matrix)
+        {
+            if (matrix.RowCount != matrix.ColumnCount)
+            {
+                throw new ArgumentException(Resources.ArgumentMatrixSquare);
+            }
+
+            if (matrix.RowCount != Factor.RowCount || matrix.ColumnCount != Factor.ColumnCount)
+            {
+                throw Matrix.DimensionsDontMatch<ArgumentException>(matrix, Factor);
+            }
+
+            var dmatrix = matrix as DenseMatrix;
+            if (dmatrix == null)
+            {
+                throw new NotSupportedException("Can only do Cholesky factorization for dense matrices at the moment.");
+            }
+
+            var dfactor = (DenseMatrix)Factor;
+
+            // Overwrite the existing Factor matrix with the input.
+            Array.Copy(dmatrix.Values, 0, dfactor.Values, 0, dmatrix.Values.Length);
+
+            // Perform factorization (while overwriting).
+            Control.LinearAlgebraProvider.CholeskyFactor(dfactor.Values, dfactor.RowCount);
+        }
     }
 }

--- a/src/Numerics/LinearAlgebra/Complex/Factorization/UserCholesky.cs
+++ b/src/Numerics/LinearAlgebra/Complex/Factorization/UserCholesky.cs
@@ -52,22 +52,20 @@ namespace MathNet.Numerics.LinearAlgebra.Complex.Factorization
     internal sealed class UserCholesky : Cholesky
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="UserCholesky"/> class. This object will compute the
-        /// Cholesky factorization when the constructor is called and cache it's factorization.
+        /// Computes the Cholesky factorization in-place.
         /// </summary>
-        /// <param name="matrix">The matrix to factor.</param>
-        /// <exception cref="ArgumentNullException">If <paramref name="matrix"/> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not a square matrix.</exception>
-        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not positive definite.</exception>
-        public static UserCholesky Create(Matrix<Complex> matrix)
+        /// <param name="factor">On entry, the matrix to factor. On exit, the Cholesky factor matrix</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="factor"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="factor"/> is not a square matrix.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="factor"/> is not positive definite.</exception>
+        static void DoCholesky(Matrix<Complex> factor)
         {
-            if (matrix.RowCount != matrix.ColumnCount)
+            if (factor.RowCount != factor.ColumnCount)
             {
                 throw new ArgumentException(Resources.ArgumentMatrixSquare);
             }
 
             // Create a new matrix for the Cholesky factor, then perform factorization (while overwriting).
-            var factor = matrix.Clone();
             var tmpColumn = new Complex[factor.RowCount];
 
             // Main loop - along the diagonal
@@ -103,8 +101,41 @@ namespace MathNet.Numerics.LinearAlgebra.Complex.Factorization
                     factor.At(ij, i, Complex.Zero);
                 }
             }
+        }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserCholesky"/> class. This object will compute the
+        /// Cholesky factorization when the constructor is called and cache it's factorization.
+        /// </summary>
+        /// <param name="matrix">The matrix to factor.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="matrix"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not a square matrix.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not positive definite.</exception>
+        public static UserCholesky Create(Matrix<Complex> matrix)
+        {
+            // Create a new matrix for the Cholesky factor, then perform factorization (while overwriting).
+            var factor = matrix.Clone();
+            DoCholesky(factor);
             return new UserCholesky(factor);
+        }
+
+        /// <summary>
+        /// Calculates the Cholesky factorization of the input matrix.
+        /// </summary>
+        /// <param name="matrix">The matrix to be factorized<see cref="Matrix{T}"/>.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="matrix"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not a square matrix.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not positive definite.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If <paramref name="matrix"/> does not have the same dimensions as the existing factor.</exception>
+        public override void Factorize(Matrix<Complex> matrix)
+        {
+            if (matrix.RowCount != Factor.RowCount || matrix.ColumnCount != Factor.ColumnCount)
+            {
+                throw Matrix.DimensionsDontMatch<ArgumentException>(matrix, Factor);
+            }
+
+            matrix.CopyTo(Factor);
+            DoCholesky(Factor);
         }
 
         UserCholesky(Matrix<Complex> factor)

--- a/src/Numerics/LinearAlgebra/Complex32/Factorization/DenseCholesky.cs
+++ b/src/Numerics/LinearAlgebra/Complex32/Factorization/DenseCholesky.cs
@@ -149,5 +149,40 @@ namespace MathNet.Numerics.LinearAlgebra.Complex32.Factorization
             var dfactor = (DenseMatrix) Factor;
             Control.LinearAlgebraProvider.CholeskySolveFactored(dfactor.Values, dfactor.RowCount, dresult.Values, 1);
         }
+
+        /// <summary>
+        /// Calculates the Cholesky factorization of the input matrix.
+        /// </summary>
+        /// <param name="matrix">The matrix to be factorized<see cref="Matrix{T}"/>.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="matrix"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not a square matrix.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not positive definite.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If <paramref name="matrix"/> does not have the same dimensions as the existing factor.</exception>
+        public override void Factorize(Matrix<Complex32> matrix)
+        {
+            if (matrix.RowCount != matrix.ColumnCount)
+            {
+                throw new ArgumentException(Resources.ArgumentMatrixSquare);
+            }
+
+            if (matrix.RowCount != Factor.RowCount || matrix.ColumnCount != Factor.ColumnCount)
+            {
+                throw Matrix.DimensionsDontMatch<ArgumentException>(matrix, Factor);
+            }
+
+            var dmatrix = matrix as DenseMatrix;
+            if (dmatrix == null)
+            {
+                throw new NotSupportedException("Can only do Cholesky factorization for dense matrices at the moment.");
+            }
+
+            var dfactor = (DenseMatrix)Factor;
+
+            // Overwrite the existing Factor matrix with the input.
+            Array.Copy(dmatrix.Values, 0, dfactor.Values, 0, dmatrix.Values.Length);
+
+            // Perform factorization (while overwriting).
+            Control.LinearAlgebraProvider.CholeskyFactor(dfactor.Values, dfactor.RowCount);
+        }
     }
 }

--- a/src/Numerics/LinearAlgebra/Complex32/Factorization/UserCholesky.cs
+++ b/src/Numerics/LinearAlgebra/Complex32/Factorization/UserCholesky.cs
@@ -47,22 +47,20 @@ namespace MathNet.Numerics.LinearAlgebra.Complex32.Factorization
     internal sealed class UserCholesky : Cholesky
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="UserCholesky"/> class. This object will compute the
-        /// Cholesky factorization when the constructor is called and cache it's factorization.
+        /// Computes the Cholesky factorization in-place.
         /// </summary>
-        /// <param name="matrix">The matrix to factor.</param>
-        /// <exception cref="ArgumentNullException">If <paramref name="matrix"/> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not a square matrix.</exception>
-        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not positive definite.</exception>
-        public static UserCholesky Create(Matrix<Complex32> matrix)
+        /// <param name="factor">On entry, the matrix to factor. On exit, the Cholesky factor matrix</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="factor"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="factor"/> is not a square matrix.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="factor"/> is not positive definite.</exception>
+        static void DoCholesky(Matrix<Complex32> factor)
         {
-            if (matrix.RowCount != matrix.ColumnCount)
+            if (factor.RowCount != factor.ColumnCount)
             {
                 throw new ArgumentException(Resources.ArgumentMatrixSquare);
             }
 
             // Create a new matrix for the Cholesky factor, then perform factorization (while overwriting).
-            var factor = matrix.Clone();
             var tmpColumn = new Complex32[factor.RowCount];
 
             // Main loop - along the diagonal
@@ -98,8 +96,41 @@ namespace MathNet.Numerics.LinearAlgebra.Complex32.Factorization
                     factor.At(ij, i, Complex32.Zero);
                 }
             }
+        }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserCholesky"/> class. This object will compute the
+        /// Cholesky factorization when the constructor is called and cache it's factorization.
+        /// </summary>
+        /// <param name="matrix">The matrix to factor.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="matrix"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not a square matrix.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not positive definite.</exception>
+        public static UserCholesky Create(Matrix<Complex32> matrix)
+        {
+            // Create a new matrix for the Cholesky factor, then perform factorization (while overwriting).
+            var factor = matrix.Clone();
+            DoCholesky(factor);
             return new UserCholesky(factor);
+        }
+
+        /// <summary>
+        /// Calculates the Cholesky factorization of the input matrix.
+        /// </summary>
+        /// <param name="matrix">The matrix to be factorized<see cref="Matrix{T}"/>.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="matrix"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not a square matrix.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not positive definite.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If <paramref name="matrix"/> does not have the same dimensions as the existing factor.</exception>
+        public override void Factorize(Matrix<Complex32> matrix)
+        {
+            if (matrix.RowCount != Factor.RowCount || matrix.ColumnCount != Factor.ColumnCount)
+            {
+                throw Matrix.DimensionsDontMatch<ArgumentException>(matrix, Factor);
+            }
+
+            matrix.CopyTo(Factor);
+            DoCholesky(Factor);
         }
 
         UserCholesky(Matrix<Complex32> factor)

--- a/src/Numerics/LinearAlgebra/Double/Factorization/DenseCholesky.cs
+++ b/src/Numerics/LinearAlgebra/Double/Factorization/DenseCholesky.cs
@@ -147,5 +147,40 @@ namespace MathNet.Numerics.LinearAlgebra.Double.Factorization
             var dfactor = (DenseMatrix) Factor;
             Control.LinearAlgebraProvider.CholeskySolveFactored(dfactor.Values, dfactor.RowCount, dresult.Values, 1);
         }
+
+        /// <summary>
+        /// Calculates the Cholesky factorization of the input matrix.
+        /// </summary>
+        /// <param name="matrix">The matrix to be factorized<see cref="Matrix{T}"/>.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="matrix"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not a square matrix.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not positive definite.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If <paramref name="matrix"/> does not have the same dimensions as the existing factor.</exception>
+        public override void Factorize(Matrix<double> matrix)
+        {
+            if (matrix.RowCount != matrix.ColumnCount)
+            {
+                throw new ArgumentException(Resources.ArgumentMatrixSquare);
+            }
+
+            if (matrix.RowCount != Factor.RowCount || matrix.ColumnCount != Factor.ColumnCount)
+            {
+                throw Matrix.DimensionsDontMatch<ArgumentException>(matrix, Factor);
+            }
+
+            var dmatrix = matrix as DenseMatrix;
+            if (dmatrix == null)
+            {
+                throw new NotSupportedException("Can only do Cholesky factorization for dense matrices at the moment.");
+            }
+
+            var dfactor = (DenseMatrix)Factor;
+
+            // Overwrite the existing Factor matrix with the input.
+            Buffer.BlockCopy(dmatrix.Values, 0, dfactor.Values, 0, dmatrix.Values.Length * Constants.SizeOfDouble);
+
+            // Perform factorization (while overwriting).
+            Control.LinearAlgebraProvider.CholeskyFactor(dfactor.Values, dfactor.RowCount);
+        }
     }
 }

--- a/src/Numerics/LinearAlgebra/Double/Factorization/UserCholesky.cs
+++ b/src/Numerics/LinearAlgebra/Double/Factorization/UserCholesky.cs
@@ -45,22 +45,19 @@ namespace MathNet.Numerics.LinearAlgebra.Double.Factorization
     internal sealed class UserCholesky : Cholesky
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="UserCholesky"/> class. This object will compute the
-        /// Cholesky factorization when the constructor is called and cache it's factorization.
+        /// Computes the Cholesky factorization in-place.
         /// </summary>
-        /// <param name="matrix">The matrix to factor.</param>
-        /// <exception cref="ArgumentNullException">If <paramref name="matrix"/> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not a square matrix.</exception>
-        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not positive definite.</exception>
-        public static UserCholesky Create(Matrix<double> matrix)
+        /// <param name="factor">On entry, the matrix to factor. On exit, the Cholesky factor matrix</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="factor"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="factor"/> is not a square matrix.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="factor"/> is not positive definite.</exception>
+        static void DoCholesky(Matrix<double> factor)
         {
-            if (matrix.RowCount != matrix.ColumnCount)
+            if (factor.RowCount != factor.ColumnCount)
             {
                 throw new ArgumentException(Resources.ArgumentMatrixSquare);
             }
 
-            // Create a new matrix for the Cholesky factor, then perform factorization (while overwriting).
-            var factor = matrix.Clone();
             var tmpColumn = new double[factor.RowCount];
 
             // Main loop - along the diagonal
@@ -96,8 +93,41 @@ namespace MathNet.Numerics.LinearAlgebra.Double.Factorization
                     factor.At(ij, i, 0.0);
                 }
             }
+        }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserCholesky"/> class. This object will compute the
+        /// Cholesky factorization when the constructor is called and cache it's factorization.
+        /// </summary>
+        /// <param name="matrix">The matrix to factor.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="matrix"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not a square matrix.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not positive definite.</exception>
+        public static UserCholesky Create(Matrix<double> matrix)
+        {
+            // Create a new matrix for the Cholesky factor, then perform factorization (while overwriting).
+            var factor = matrix.Clone();
+            DoCholesky(factor);
             return new UserCholesky(factor);
+        }
+
+        /// <summary>
+        /// Calculates the Cholesky factorization of the input matrix.
+        /// </summary>
+        /// <param name="matrix">The matrix to be factorized<see cref="Matrix{T}"/>.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="matrix"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not a square matrix.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not positive definite.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If <paramref name="matrix"/> does not have the same dimensions as the existing factor.</exception>
+        public override void Factorize(Matrix<double> matrix)
+        {
+            if (matrix.RowCount != Factor.RowCount || matrix.ColumnCount != Factor.ColumnCount)
+            {
+                throw Matrix.DimensionsDontMatch<ArgumentException>(matrix, Factor);
+            }
+
+            matrix.CopyTo(Factor);
+            DoCholesky(Factor);
         }
 
         UserCholesky(Matrix<double> factor)

--- a/src/Numerics/LinearAlgebra/Factorization/Cholesky.cs
+++ b/src/Numerics/LinearAlgebra/Factorization/Cholesky.cs
@@ -65,6 +65,12 @@ namespace MathNet.Numerics.LinearAlgebra.Factorization
         public abstract T DeterminantLn { get; }
 
         /// <summary>
+        /// Calculates the Cholesky factorization of the input matrix.
+        /// </summary>
+        /// <param name="matrix">The matrix to be factorized<see cref="Matrix{T}"/>.</param>
+        public abstract void Factorize(Matrix<T> matrix);
+
+        /// <summary>
         /// Solves a system of linear equations, <b>AX = B</b>, with A Cholesky factorized.
         /// </summary>
         /// <param name="input">The right hand side <see cref="Matrix{T}"/>, <b>B</b>.</param>

--- a/src/Numerics/LinearAlgebra/Single/Factorization/DenseCholesky.cs
+++ b/src/Numerics/LinearAlgebra/Single/Factorization/DenseCholesky.cs
@@ -147,5 +147,40 @@ namespace MathNet.Numerics.LinearAlgebra.Single.Factorization
             var dfactor = (DenseMatrix) Factor;
             Control.LinearAlgebraProvider.CholeskySolveFactored(dfactor.Values, dfactor.RowCount, dresult.Values, 1);
         }
+
+        /// <summary>
+        /// Calculates the Cholesky factorization of the input matrix.
+        /// </summary>
+        /// <param name="matrix">The matrix to be factorized<see cref="Matrix{T}"/>.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="matrix"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not a square matrix.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="matrix"/> is not positive definite.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If <paramref name="matrix"/> does not have the same dimensions as the existing factor.</exception>
+        public override void Factorize(Matrix<float> matrix)
+        {
+            if (matrix.RowCount != matrix.ColumnCount)
+            {
+                throw new ArgumentException(Resources.ArgumentMatrixSquare);
+            }
+
+            if (matrix.RowCount != Factor.RowCount || matrix.ColumnCount != Factor.ColumnCount)
+            {
+                throw Matrix.DimensionsDontMatch<ArgumentException>(matrix, Factor);
+            }
+
+            var dmatrix = matrix as DenseMatrix;
+            if (dmatrix == null)
+            {
+                throw new NotSupportedException("Can only do Cholesky factorization for dense matrices at the moment.");
+            }
+
+            var dfactor = (DenseMatrix)Factor;
+
+            // Overwrite the existing Factor matrix with the input.
+            Buffer.BlockCopy(dmatrix.Values, 0, dfactor.Values, 0, dmatrix.Values.Length * Constants.SizeOfFloat);
+
+            // Perform factorization (while overwriting).
+            Control.LinearAlgebraProvider.CholeskyFactor(dfactor.Values, dfactor.RowCount);
+        }
     }
 }

--- a/src/UnitTests/LinearAlgebraTests/Complex/Factorization/CholeskyTests.cs
+++ b/src/UnitTests/LinearAlgebraTests/Complex/Factorization/CholeskyTests.cs
@@ -143,6 +143,22 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Complex.Factorization
                     AssertHelpers.AlmostEqualRelative(matrixX[i, j], matrixXfromC[i, j], 8);
                 }
             }
+
+            // Check update
+            var matrixC = Matrix<Complex>.Build.RandomPositiveDefinite(order, 1);
+            var cholC = matrixC.Cholesky();
+            chol.Factorize(matrixC);
+            for (var i = 0; i < matrixC.RowCount; i++)
+            {
+                for (var j = 0; j < matrixC.ColumnCount; j++)
+                {
+                    Assert.AreEqual(cholC.Factor[i, j], chol.Factor[i, j]);
+                }
+            }
+
+            // Check size mismatch
+            var matrixD = Matrix<Complex>.Build.DenseIdentity(order + 1);
+            Assert.That(() => chol.Factorize(matrixD), Throws.ArgumentException);
         }
 
         /// <summary>

--- a/src/UnitTests/LinearAlgebraTests/Complex/Factorization/UserCholeskyTests.cs
+++ b/src/UnitTests/LinearAlgebraTests/Complex/Factorization/UserCholeskyTests.cs
@@ -142,6 +142,22 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Complex.Factorization
                     AssertHelpers.AlmostEqualRelative(matrixX[i, j], matrixXfromC[i, j], 8);
                 }
             }
+
+            // Check update
+            var matrixC = Matrix<Complex>.Build.RandomPositiveDefinite(order, 1);
+            var cholC = matrixC.Cholesky();
+            chol.Factorize(matrixC);
+            for (var i = 0; i < matrixC.RowCount; i++)
+            {
+                for (var j = 0; j < matrixC.ColumnCount; j++)
+                {
+                    Assert.AreEqual(cholC.Factor[i, j], chol.Factor[i, j]);
+                }
+            }
+
+            // Check size mismatch
+            var matrixD = Matrix<Complex>.Build.DenseIdentity(order + 1);
+            Assert.That(() => chol.Factorize(matrixD), Throws.ArgumentException);
         }
 
         /// <summary>

--- a/src/UnitTests/LinearAlgebraTests/Complex32/Factorization/CholeskyTests.cs
+++ b/src/UnitTests/LinearAlgebraTests/Complex32/Factorization/CholeskyTests.cs
@@ -140,6 +140,22 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Complex32.Factorization
                     Assert.AreEqual(matrixX[i, j].Imaginary, matrixXfromC[i, j].Imaginary, 1e-3f);
                 }
             }
+
+            // Check update
+            var matrixC = Matrix<Complex32>.Build.RandomPositiveDefinite(order, 1);
+            var cholC = matrixC.Cholesky();
+            chol.Factorize(matrixC);
+            for (var i = 0; i < matrixC.RowCount; i++)
+            {
+                for (var j = 0; j < matrixC.ColumnCount; j++)
+                {
+                    Assert.AreEqual(cholC.Factor[i, j], chol.Factor[i, j]);
+                }
+            }
+
+            // Check size mismatch
+            var matrixD = Matrix<Complex32>.Build.DenseIdentity(order + 1);
+            Assert.That(() => chol.Factorize(matrixD), Throws.ArgumentException);
         }
 
         /// <summary>

--- a/src/UnitTests/LinearAlgebraTests/Complex32/Factorization/UserCholeskyTests.cs
+++ b/src/UnitTests/LinearAlgebraTests/Complex32/Factorization/UserCholeskyTests.cs
@@ -139,6 +139,22 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Complex32.Factorization
                     Assert.AreEqual(matrixX[i, j].Imaginary, matrixXfromC[i, j].Imaginary, 1e-3f);
                 }
             }
+
+            // Check update
+            var matrixC = Matrix<Complex32>.Build.RandomPositiveDefinite(order, 1);
+            var cholC = matrixC.Cholesky();
+            chol.Factorize(matrixC);
+            for (var i = 0; i < matrixC.RowCount; i++)
+            {
+                for (var j = 0; j < matrixC.ColumnCount; j++)
+                {
+                    Assert.AreEqual(cholC.Factor[i, j], chol.Factor[i, j]);
+                }
+            }
+
+            // Check size mismatch
+            var matrixD = Matrix<Complex32>.Build.DenseIdentity(order + 1);
+            Assert.That(() => chol.Factorize(matrixD), Throws.ArgumentException);
         }
 
         /// <summary>

--- a/src/UnitTests/LinearAlgebraTests/Double/Factorization/CholeskyTests.cs
+++ b/src/UnitTests/LinearAlgebraTests/Double/Factorization/CholeskyTests.cs
@@ -218,6 +218,22 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Double.Factorization
                     Assert.AreEqual(matrixACopy[i, j], matrixA[i, j]);
                 }
             }
+
+            // Check update
+            var matrixC = Matrix<double>.Build.RandomPositiveDefinite(row, 1);
+            var cholC = matrixC.Cholesky();
+            chol.Factorize(matrixC);
+            for (var i = 0; i < matrixC.RowCount; i++)
+            {
+                for (var j = 0; j < matrixC.ColumnCount; j++)
+                {
+                    Assert.AreEqual(cholC.Factor[i, j], chol.Factor[i, j]);
+                }
+            }
+
+            // Check size mismatch
+            var matrixD = Matrix<double>.Build.DenseIdentity(row+1);
+            Assert.That(() => chol.Factorize(matrixD), Throws.ArgumentException);
         }
 
         /// <summary>

--- a/src/UnitTests/LinearAlgebraTests/Double/Factorization/UserCholeskyTests.cs
+++ b/src/UnitTests/LinearAlgebraTests/Double/Factorization/UserCholeskyTests.cs
@@ -136,6 +136,22 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Double.Factorization
                     Assert.AreEqual(matrixX[i, j], matrixXfromC[i, j], 1.0e-11);
                 }
             }
+
+            // Check update
+            var matrixC = Matrix<double>.Build.RandomPositiveDefinite(order, 1);
+            var cholC = matrixC.Cholesky();
+            chol.Factorize(matrixC);
+            for (var i = 0; i < matrixC.RowCount; i++)
+            {
+                for (var j = 0; j < matrixC.ColumnCount; j++)
+                {
+                    Assert.AreEqual(cholC.Factor[i, j], chol.Factor[i, j]);
+                }
+            }
+
+            // Check size mismatch
+            var matrixD = Matrix<double>.Build.DenseIdentity(order + 1);
+            Assert.That(() => chol.Factorize(matrixD), Throws.ArgumentException);
         }
 
         /// <summary>

--- a/src/UnitTests/LinearAlgebraTests/Single/Factorization/CholeskyTests.cs
+++ b/src/UnitTests/LinearAlgebraTests/Single/Factorization/CholeskyTests.cs
@@ -137,6 +137,22 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Single.Factorization
                     Assert.AreEqual(matrixX[i, j], matrixXfromC[i, j], 1e-3);
                 }
             }
+
+            // Check update
+            var matrixC = Matrix<float>.Build.RandomPositiveDefinite(order, 1);
+            var cholC = matrixC.Cholesky();
+            chol.Factorize(matrixC);
+            for (var i = 0; i < matrixC.RowCount; i++)
+            {
+                for (var j = 0; j < matrixC.ColumnCount; j++)
+                {
+                    Assert.AreEqual(cholC.Factor[i, j], chol.Factor[i, j]);
+                }
+            }
+
+            // Check size mismatch
+            var matrixD = Matrix<float>.Build.DenseIdentity(order + 1);
+            Assert.That(() => chol.Factorize(matrixD), Throws.ArgumentException);
         }
 
         /// <summary>

--- a/src/UnitTests/LinearAlgebraTests/Single/Factorization/UserCholeskyTests.cs
+++ b/src/UnitTests/LinearAlgebraTests/Single/Factorization/UserCholeskyTests.cs
@@ -136,6 +136,22 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Single.Factorization
                     Assert.AreEqual(matrixX[i, j], matrixXfromC[i, j], 1e-3);
                 }
             }
+
+            // Check update
+            var matrixC = Matrix<float>.Build.RandomPositiveDefinite(order, 1);
+            var cholC = matrixC.Cholesky();
+            chol.Factorize(matrixC);
+            for (var i = 0; i < matrixC.RowCount; i++)
+            {
+                for (var j = 0; j < matrixC.ColumnCount; j++)
+                {
+                    Assert.AreEqual(cholC.Factor[i, j], chol.Factor[i, j]);
+                }
+            }
+
+            // Check size mismatch
+            var matrixD = Matrix<float>.Build.DenseIdentity(order + 1);
+            Assert.That(() => chol.Factorize(matrixD), Throws.ArgumentException);
         }
 
         /// <summary>


### PR DESCRIPTION
Allows factorization with re-use of an existing factor matrix, and corresponding implementations and unit tests.

Partially addresses issue #431 