### PR TITLE
Single precision Fourier Transform support

### DIFF
--- a/src/Numerics/ComplexExtensions.cs
+++ b/src/Numerics/ComplexExtensions.cs
@@ -48,6 +48,16 @@ namespace MathNet.Numerics
         /// <summary>
         /// Gets the squared magnitude of the <c>Complex</c> number.
         /// </summary>
+        /// <param name="complex">The <see cref="Complex32"/> number to perfom this operation on.</param>
+        /// <returns>The squared magnitude of the <c>Complex</c> number.</returns>
+        public static double MagnitudeSquared(this Complex32 complex)
+        {
+            return (complex.Real * complex.Real) + (complex.Imaginary * complex.Imaginary);
+        }
+
+        /// <summary>
+        /// Gets the squared magnitude of the <c>Complex</c> number.
+        /// </summary>
         /// <param name="complex">The <see cref="Complex"/> number to perfom this operation on.</param>
         /// <returns>The squared magnitude of the <c>Complex</c> number.</returns>
         public static double MagnitudeSquared(this Complex complex)

--- a/src/Numerics/IntegralTransforms/Fourier.Bluestein.cs
+++ b/src/Numerics/IntegralTransforms/Fourier.Bluestein.cs
@@ -52,6 +52,38 @@ namespace MathNet.Numerics.IntegralTransforms
         /// </summary>
         /// <param name="n">Number of samples.</param>
         /// <returns>Bluestein sequence exp(I*Pi*k^2/N)</returns>
+        static Complex32[] BluesteinSequence32(int n)
+        {
+            double s = Constants.Pi / n;
+            var sequence = new Complex32[n];
+
+            // TODO: benchmark whether the second variation is significantly
+            // faster than the former one. If not just use the former one always.
+            if (n > BluesteinSequenceLengthThreshold)
+            {
+                for (int k = 0; k < sequence.Length; k++)
+                {
+                    double t = (s * k) * k;
+                    sequence[k] = new Complex32((float)Math.Cos(t), (float)Math.Sin(t));
+                }
+            }
+            else
+            {
+                for (int k = 0; k < sequence.Length; k++)
+                {
+                    double t = s * (k * k);
+                    sequence[k] = new Complex32((float)Math.Cos(t), (float)Math.Sin(t));
+                }
+            }
+
+            return sequence;
+        }
+
+        /// <summary>
+        /// Generate the bluestein sequence for the provided problem size.
+        /// </summary>
+        /// <param name="n">Number of samples.</param>
+        /// <returns>Bluestein sequence exp(I*Pi*k^2/N)</returns>
         static Complex[] BluesteinSequence(int n)
         {
             double s = Constants.Pi/n;
@@ -77,6 +109,61 @@ namespace MathNet.Numerics.IntegralTransforms
             }
 
             return sequence;
+        }
+
+        /// <summary>
+        /// Convolution with the bluestein sequence (Parallel Version).
+        /// </summary>
+        /// <param name="samples">Sample Vector.</param>
+        static void BluesteinConvolutionParallel(Complex32[] samples)
+        {
+            int n = samples.Length;
+            Complex32[] sequence = BluesteinSequence32(n);
+
+            // Padding to power of two >= 2N–1 so we can apply Radix-2 FFT.
+            int m = ((n << 1) - 1).CeilingToPowerOfTwo();
+            var b = new Complex32[m];
+            var a = new Complex32[m];
+
+            CommonParallel.Invoke(
+                () =>
+                {
+                    // Build and transform padded sequence b_k = exp(I*Pi*k^2/N)
+                    for (int i = 0; i < n; i++)
+                    {
+                        b[i] = sequence[i];
+                    }
+
+                    for (int i = m - n + 1; i < b.Length; i++)
+                    {
+                        b[i] = sequence[m - i];
+                    }
+
+                    Radix2(b, -1);
+                },
+                () =>
+                {
+                    // Build and transform padded sequence a_k = x_k * exp(-I*Pi*k^2/N)
+                    for (int i = 0; i < samples.Length; i++)
+                    {
+                        a[i] = sequence[i].Conjugate() * samples[i];
+                    }
+
+                    Radix2(a, -1);
+                });
+
+            for (int i = 0; i < a.Length; i++)
+            {
+                a[i] *= b[i];
+            }
+
+            Radix2Parallel(a, 1);
+
+            var nbinv = 1.0f / m;
+            for (int i = 0; i < samples.Length; i++)
+            {
+                samples[i] = nbinv * sequence[i].Conjugate() * a[i];
+            }
         }
 
         /// <summary>
@@ -138,11 +225,50 @@ namespace MathNet.Numerics.IntegralTransforms
         /// Swap the real and imaginary parts of each sample.
         /// </summary>
         /// <param name="samples">Sample Vector.</param>
+        static void SwapRealImaginary(Complex32[] samples)
+        {
+            for (int i = 0; i < samples.Length; i++)
+            {
+                samples[i] = new Complex32(samples[i].Imaginary, samples[i].Real);
+            }
+        }
+
+        /// <summary>
+        /// Swap the real and imaginary parts of each sample.
+        /// </summary>
+        /// <param name="samples">Sample Vector.</param>
         static void SwapRealImaginary(Complex[] samples)
         {
             for (int i = 0; i < samples.Length; i++)
             {
                 samples[i] = new Complex(samples[i].Imaginary, samples[i].Real);
+            }
+        }
+
+        /// <summary>
+        /// Bluestein generic FFT for arbitrary sized sample vectors.
+        /// </summary>
+        /// <param name="samples">Time-space sample vector.</param>
+        /// <param name="exponentSign">Fourier series exponent sign.</param>
+        internal static void Bluestein(Complex32[] samples, int exponentSign)
+        {
+            int n = samples.Length;
+            if (n.IsPowerOfTwo())
+            {
+                Radix2Parallel(samples, exponentSign);
+                return;
+            }
+
+            if (exponentSign == 1)
+            {
+                SwapRealImaginary(samples);
+            }
+
+            BluesteinConvolutionParallel(samples);
+
+            if (exponentSign == 1)
+            {
+                SwapRealImaginary(samples);
             }
         }
 

--- a/src/Numerics/IntegralTransforms/Fourier.Naive.cs
+++ b/src/Numerics/IntegralTransforms/Fourier.Naive.cs
@@ -47,6 +47,36 @@ namespace MathNet.Numerics.IntegralTransforms
         /// <param name="samples">Time-space sample vector.</param>
         /// <param name="exponentSign">Fourier series exponent sign.</param>
         /// <returns>Corresponding frequency-space vector.</returns>
+        internal static Complex32[] Naive(Complex32[] samples, int exponentSign)
+        {
+            var w0 = exponentSign * Constants.Pi2 / samples.Length;
+            var spectrum = new Complex32[samples.Length];
+
+            CommonParallel.For(0, samples.Length, (u, v) =>
+            {
+                for (int i = u; i < v; i++)
+                {
+                    var wk = w0 * i;
+                    var sum = Complex32.Zero;
+                    for (var n = 0; n < samples.Length; n++)
+                    {
+                        var w = n * wk;
+                        sum += samples[n] * new Complex32((float)Math.Cos(w), (float)Math.Sin(w));
+                    }
+
+                    spectrum[i] = sum;
+                }
+            });
+
+            return spectrum;
+        }
+
+        /// <summary>
+        /// Naive generic DFT, useful e.g. to verify faster algorithms.
+        /// </summary>
+        /// <param name="samples">Time-space sample vector.</param>
+        /// <param name="exponentSign">Fourier series exponent sign.</param>
+        /// <returns>Corresponding frequency-space vector.</returns>
         internal static Complex[] Naive(Complex[] samples, int exponentSign)
         {
             var w0 = exponentSign*Constants.Pi2/samples.Length;

--- a/src/Numerics/IntegralTransforms/Fourier.cs
+++ b/src/Numerics/IntegralTransforms/Fourier.cs
@@ -48,9 +48,44 @@ namespace MathNet.Numerics.IntegralTransforms
         /// Applies the forward Fast Fourier Transform (FFT) to arbitrary-length sample vectors.
         /// </summary>
         /// <param name="samples">Sample vector, where the FFT is evaluated in place.</param>
+        public static void Forward(Complex32[] samples)
+        {
+            Control.FourierTransformProvider.Forward(samples, FourierTransformScaling.SymmetricScaling);
+        }
+
+        /// <summary>
+        /// Applies the forward Fast Fourier Transform (FFT) to arbitrary-length sample vectors.
+        /// </summary>
+        /// <param name="samples">Sample vector, where the FFT is evaluated in place.</param>
         public static void Forward(Complex[] samples)
         {
             Control.FourierTransformProvider.Forward(samples, FourierTransformScaling.SymmetricScaling);
+        }
+        
+        /// <summary>
+        /// Applies the forward Fast Fourier Transform (FFT) to arbitrary-length sample vectors.
+        /// </summary>
+        /// <param name="samples">Sample vector, where the FFT is evaluated in place.</param>
+        /// <param name="options">Fourier Transform Convention Options.</param>
+        public static void Forward(Complex32[] samples, FourierOptions options)
+        {
+            switch (options)
+            {
+                case FourierOptions.NoScaling:
+                case FourierOptions.AsymmetricScaling:
+                    Control.FourierTransformProvider.Forward(samples, FourierTransformScaling.NoScaling);
+                    break;
+                case FourierOptions.InverseExponent:
+                    Control.FourierTransformProvider.Backward(samples, FourierTransformScaling.SymmetricScaling);
+                    break;
+                case FourierOptions.InverseExponent | FourierOptions.NoScaling:
+                case FourierOptions.InverseExponent | FourierOptions.AsymmetricScaling:
+                    Control.FourierTransformProvider.Backward(samples, FourierTransformScaling.NoScaling);
+                    break;
+                default:
+                    Control.FourierTransformProvider.Forward(samples, FourierTransformScaling.SymmetricScaling);
+                    break;
+            }
         }
 
         /// <summary>
@@ -76,6 +111,37 @@ namespace MathNet.Numerics.IntegralTransforms
                 default:
                     Control.FourierTransformProvider.Forward(samples, FourierTransformScaling.SymmetricScaling);
                     break;
+            }
+        }
+        
+        /// <summary>
+        /// Applies the forward Fast Fourier Transform (FFT) to arbitrary-length sample vectors.
+        /// </summary>
+        /// <param name="real">Real part of the sample vector, where the FFT is evaluated in place.</param>
+        /// <param name="imaginary">Imaginary part of the sample vector, where the FFT is evaluated in place.</param>
+        /// <param name="options">Fourier Transform Convention Options.</param>
+        public static void Forward(float[] real, float[] imaginary, FourierOptions options = FourierOptions.Default)
+        {
+            if (real.Length != imaginary.Length)
+            {
+                throw new ArgumentException(Resources.ArgumentArraysSameLength);
+            }
+
+            // TODO: consider to support this natively by the provider, without the need for copying
+            // TODO: otherwise, consider ArrayPool
+
+            Complex32[] data = new Complex32[real.Length];
+            for (int i = 0; i < data.Length; i++)
+            {
+                data[i] = new Complex32(real[i], imaginary[i]);
+            }
+
+            Forward(data, options);
+
+            for (int i = 0; i < data.Length; i++)
+            {
+                real[i] = data[i].Real;
+                imaginary[i] = data[i].Imaginary;
             }
         }
 
@@ -107,6 +173,40 @@ namespace MathNet.Numerics.IntegralTransforms
             {
                 real[i] = data[i].Real;
                 imaginary[i] = data[i].Imaginary;
+            }
+        }
+        
+        /// <summary>
+        /// Packed Real-Complex forward Fast Fourier Transform (FFT) to arbitrary-length sample vectors.
+        /// Since for real-valued time samples the complex spectrum is conjugate-even (symmetry),
+        /// the spectrum can be fully reconstructed form the positive frequencies only (first half).
+        /// The data array needs to be N+2 (if N is even) or N+1 (if N is odd) long in order to support such a packed spectrum.
+        /// </summary>
+        /// <param name="data">Data array of length N+2 (if N is even) or N+1 (if N is odd).</param>
+        /// <param name="n">The number of samples.</param>
+        /// <param name="options">Fourier Transform Convention Options.</param>
+        public static void ForwardReal(float[] data, int n, FourierOptions options = FourierOptions.Default)
+        {
+            int length = n.IsEven() ? n + 2 : n + 1;
+            if (data.Length < length)
+            {
+                throw new ArgumentException(string.Format(Resources.ArrayTooSmall, length));
+            }
+
+            if ((options & FourierOptions.InverseExponent) == FourierOptions.InverseExponent)
+            {
+                throw new NotSupportedException();
+            }
+
+            switch (options)
+            {
+                case FourierOptions.NoScaling:
+                case FourierOptions.AsymmetricScaling:
+                    Control.FourierTransformProvider.ForwardReal(data, n, FourierTransformScaling.NoScaling);
+                    break;
+                default:
+                    Control.FourierTransformProvider.ForwardReal(data, n, FourierTransformScaling.SymmetricScaling);
+                    break;
             }
         }
 
@@ -153,7 +253,7 @@ namespace MathNet.Numerics.IntegralTransforms
         /// For example, with two dimensions "rows" and "columns" the samples are assumed to be organized row by row.
         /// </param>
         /// <param name="options">Fourier Transform Convention Options.</param>
-        public static void ForwardMultiDim(Complex[] samples, int[] dimensions, FourierOptions options = FourierOptions.Default)
+        public static void ForwardMultiDim(Complex32[] samples, int[] dimensions, FourierOptions options = FourierOptions.Default)
         {
             switch (options)
             {
@@ -175,6 +275,49 @@ namespace MathNet.Numerics.IntegralTransforms
         }
 
         /// <summary>
+        /// Applies the forward Fast Fourier Transform (FFT) to multiple dimensional sample data.
+        /// </summary>
+        /// <param name="samples">Sample data, where the FFT is evaluated in place.</param>
+        /// <param name="dimensions">
+        /// The data size per dimension. The first dimension is the major one.
+        /// For example, with two dimensions "rows" and "columns" the samples are assumed to be organized row by row.
+        /// </param>
+        /// <param name="options">Fourier Transform Convention Options.</param>
+        public static void ForwardMultiDim(Complex[] samples, int[] dimensions, FourierOptions options = FourierOptions.Default)
+        {
+            switch (options)
+            {
+                case FourierOptions.NoScaling:
+                case FourierOptions.AsymmetricScaling:
+                    Control.FourierTransformProvider.ForwardMultidim(samples, dimensions, FourierTransformScaling.NoScaling);
+                    break;
+                case FourierOptions.InverseExponent:
+                    Control.FourierTransformProvider.BackwardMultidim(samples, dimensions, FourierTransformScaling.SymmetricScaling);
+                    break;
+                case FourierOptions.InverseExponent | FourierOptions.NoScaling:
+                case FourierOptions.InverseExponent | FourierOptions.AsymmetricScaling:
+                    Control.FourierTransformProvider.BackwardMultidim(samples, dimensions, FourierTransformScaling.NoScaling);
+                    break;
+                default:
+                    Control.FourierTransformProvider.ForwardMultidim(samples, dimensions, FourierTransformScaling.SymmetricScaling);
+                    break;
+            }
+        }
+        
+        /// <summary>
+        /// Applies the forward Fast Fourier Transform (FFT) to two dimensional sample data.
+        /// </summary>
+        /// <param name="samplesRowWise">Sample data, organized row by row, where the FFT is evaluated in place</param>
+        /// <param name="rows">The number of rows.</param>
+        /// <param name="columns">The number of columns.</param>
+        /// <remarks>Data available organized column by column instead of row by row can be processed directly by swapping the rows and columns arguments.</remarks>
+        /// <param name="options">Fourier Transform Convention Options.</param>
+        public static void Forward2D(Complex32[] samplesRowWise, int rows, int columns, FourierOptions options = FourierOptions.Default)
+        {
+            ForwardMultiDim(samplesRowWise, new[] { rows, columns }, options);
+        }
+
+        /// <summary>
         /// Applies the forward Fast Fourier Transform (FFT) to two dimensional sample data.
         /// </summary>
         /// <param name="samplesRowWise">Sample data, organized row by row, where the FFT is evaluated in place</param>
@@ -185,6 +328,34 @@ namespace MathNet.Numerics.IntegralTransforms
         public static void Forward2D(Complex[] samplesRowWise, int rows, int columns, FourierOptions options = FourierOptions.Default)
         {
             ForwardMultiDim(samplesRowWise, new[] { rows, columns }, options);
+        }
+        
+        /// <summary>
+        /// Applies the forward Fast Fourier Transform (FFT) to a two dimensional data in form of a matrix.
+        /// </summary>
+        /// <param name="samples">Sample matrix, where the FFT is evaluated in place</param>
+        /// <param name="options">Fourier Transform Convention Options.</param>
+        public static void Forward2D(Matrix<Complex32> samples, FourierOptions options = FourierOptions.Default)
+        {
+            var rowMajorArray = samples.AsRowMajorArray();
+            if (rowMajorArray != null)
+            {
+                ForwardMultiDim(rowMajorArray, new[] { samples.RowCount, samples.ColumnCount }, options);
+                return;
+            }
+
+            var columnMajorArray = samples.AsColumnMajorArray();
+            if (columnMajorArray != null)
+            {
+                ForwardMultiDim(columnMajorArray, new[] { samples.ColumnCount, samples.RowCount }, options);
+                return;
+            }
+
+            // Fall Back
+            columnMajorArray = samples.ToColumnMajorArray();
+            ForwardMultiDim(columnMajorArray, new[] { samples.ColumnCount, samples.RowCount }, options);
+            var denseStorage = new DenseColumnMajorMatrixStorage<Complex32>(samples.RowCount, samples.ColumnCount, columnMajorArray);
+            denseStorage.CopyToUnchecked(samples.Storage, ExistingData.Clear);
         }
 
         /// <summary>
@@ -219,9 +390,48 @@ namespace MathNet.Numerics.IntegralTransforms
         /// Applies the inverse Fast Fourier Transform (iFFT) to arbitrary-length sample vectors.
         /// </summary>
         /// <param name="spectrum">Spectrum data, where the iFFT is evaluated in place.</param>
+        public static void Inverse(Complex32[] spectrum)
+        {
+            Control.FourierTransformProvider.Backward(spectrum, FourierTransformScaling.SymmetricScaling);
+        }
+
+        /// <summary>
+        /// Applies the inverse Fast Fourier Transform (iFFT) to arbitrary-length sample vectors.
+        /// </summary>
+        /// <param name="spectrum">Spectrum data, where the iFFT is evaluated in place.</param>
         public static void Inverse(Complex[] spectrum)
         {
             Control.FourierTransformProvider.Backward(spectrum, FourierTransformScaling.SymmetricScaling);
+        }
+
+        /// <summary>
+        /// Applies the inverse Fast Fourier Transform (iFFT) to arbitrary-length sample vectors.
+        /// </summary>
+        /// <param name="spectrum">Spectrum data, where the iFFT is evaluated in place.</param>
+        /// <param name="options">Fourier Transform Convention Options.</param>
+        public static void Inverse(Complex32[] spectrum, FourierOptions options)
+        {
+            switch (options)
+            {
+                case FourierOptions.NoScaling:
+                    Control.FourierTransformProvider.Backward(spectrum, FourierTransformScaling.NoScaling);
+                    break;
+                case FourierOptions.AsymmetricScaling:
+                    Control.FourierTransformProvider.Backward(spectrum, FourierTransformScaling.BackwardScaling);
+                    break;
+                case FourierOptions.InverseExponent:
+                    Control.FourierTransformProvider.Forward(spectrum, FourierTransformScaling.SymmetricScaling);
+                    break;
+                case FourierOptions.InverseExponent | FourierOptions.NoScaling:
+                    Control.FourierTransformProvider.Forward(spectrum, FourierTransformScaling.NoScaling);
+                    break;
+                case FourierOptions.InverseExponent | FourierOptions.AsymmetricScaling:
+                    Control.FourierTransformProvider.Forward(spectrum, FourierTransformScaling.ForwardScaling);
+                    break;
+                default:
+                    Control.FourierTransformProvider.Backward(spectrum, FourierTransformScaling.SymmetricScaling);
+                    break;
+            }
         }
 
         /// <summary>
@@ -260,6 +470,37 @@ namespace MathNet.Numerics.IntegralTransforms
         /// <param name="real">Real part of the sample vector, where the iFFT is evaluated in place.</param>
         /// <param name="imaginary">Imaginary part of the sample vector, where the iFFT is evaluated in place.</param>
         /// <param name="options">Fourier Transform Convention Options.</param>
+        public static void Inverse(float[] real, float[] imaginary, FourierOptions options = FourierOptions.Default)
+        {
+            if (real.Length != imaginary.Length)
+            {
+                throw new ArgumentException(Resources.ArgumentArraysSameLength);
+            }
+
+            // TODO: consider to support this natively by the provider, without the need for copying
+            // TODO: otherwise, consider ArrayPool
+
+            Complex32[] data = new Complex32[real.Length];
+            for (int i = 0; i < data.Length; i++)
+            {
+                data[i] = new Complex32(real[i], imaginary[i]);
+            }
+
+            Inverse(data, options);
+
+            for (int i = 0; i < data.Length; i++)
+            {
+                real[i] = data[i].Real;
+                imaginary[i] = data[i].Imaginary;
+            }
+        }
+        
+        /// <summary>
+        /// Applies the inverse Fast Fourier Transform (iFFT) to arbitrary-length sample vectors.
+        /// </summary>
+        /// <param name="real">Real part of the sample vector, where the iFFT is evaluated in place.</param>
+        /// <param name="imaginary">Imaginary part of the sample vector, where the iFFT is evaluated in place.</param>
+        /// <param name="options">Fourier Transform Convention Options.</param>
         public static void Inverse(double[] real, double[] imaginary, FourierOptions options = FourierOptions.Default)
         {
             if (real.Length != imaginary.Length)
@@ -282,6 +523,42 @@ namespace MathNet.Numerics.IntegralTransforms
             {
                 real[i] = data[i].Real;
                 imaginary[i] = data[i].Imaginary;
+            }
+        }
+
+        /// <summary>
+        /// Packed Real-Complex inverse Fast Fourier Transform (iFFT) to arbitrary-length sample vectors.
+        /// Since for real-valued time samples the complex spectrum is conjugate-even (symmetry),
+        /// the spectrum can be fully reconstructed form the positive frequencies only (first half).
+        /// The data array needs to be N+2 (if N is even) or N+1 (if N is odd) long in order to support such a packed spectrum.
+        /// </summary>
+        /// <param name="data">Data array of length N+2 (if N is even) or N+1 (if N is odd).</param>
+        /// <param name="n">The number of samples.</param>
+        /// <param name="options">Fourier Transform Convention Options.</param>
+        public static void InverseReal(float[] data, int n, FourierOptions options = FourierOptions.Default)
+        {
+            int length = n.IsEven() ? n + 2 : n + 1;
+            if (data.Length < length)
+            {
+                throw new ArgumentException(string.Format(Resources.ArrayTooSmall, length));
+            }
+
+            if ((options & FourierOptions.InverseExponent) == FourierOptions.InverseExponent)
+            {
+                throw new NotSupportedException();
+            }
+
+            switch (options)
+            {
+                case FourierOptions.NoScaling:
+                    Control.FourierTransformProvider.BackwardReal(data, n, FourierTransformScaling.NoScaling);
+                    break;
+                case FourierOptions.AsymmetricScaling:
+                    Control.FourierTransformProvider.BackwardReal(data, n, FourierTransformScaling.BackwardScaling);
+                    break;
+                default:
+                    Control.FourierTransformProvider.BackwardReal(data, n, FourierTransformScaling.SymmetricScaling);
+                    break;
             }
         }
 
@@ -330,6 +607,40 @@ namespace MathNet.Numerics.IntegralTransforms
         /// For example, with two dimensions "rows" and "columns" the samples are assumed to be organized row by row.
         /// </param>
         /// <param name="options">Fourier Transform Convention Options.</param>
+        public static void InverseMultiDim(Complex32[] spectrum, int[] dimensions, FourierOptions options = FourierOptions.Default)
+        {
+            switch (options)
+            {
+                case FourierOptions.NoScaling:
+                    Control.FourierTransformProvider.BackwardMultidim(spectrum, dimensions, FourierTransformScaling.NoScaling);
+                    break;
+                case FourierOptions.AsymmetricScaling:
+                    Control.FourierTransformProvider.BackwardMultidim(spectrum, dimensions, FourierTransformScaling.BackwardScaling);
+                    break;
+                case FourierOptions.InverseExponent:
+                    Control.FourierTransformProvider.ForwardMultidim(spectrum, dimensions, FourierTransformScaling.SymmetricScaling);
+                    break;
+                case FourierOptions.InverseExponent | FourierOptions.NoScaling:
+                    Control.FourierTransformProvider.ForwardMultidim(spectrum, dimensions, FourierTransformScaling.NoScaling);
+                    break;
+                case FourierOptions.InverseExponent | FourierOptions.AsymmetricScaling:
+                    Control.FourierTransformProvider.ForwardMultidim(spectrum, dimensions, FourierTransformScaling.ForwardScaling);
+                    break;
+                default:
+                    Control.FourierTransformProvider.BackwardMultidim(spectrum, dimensions, FourierTransformScaling.SymmetricScaling);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Applies the inverse Fast Fourier Transform (iFFT) to multiple dimensional sample data.
+        /// </summary>
+        /// <param name="spectrum">Spectrum data, where the iFFT is evaluated in place.</param>
+        /// <param name="dimensions">
+        /// The data size per dimension. The first dimension is the major one.
+        /// For example, with two dimensions "rows" and "columns" the samples are assumed to be organized row by row.
+        /// </param>
+        /// <param name="options">Fourier Transform Convention Options.</param>
         public static void InverseMultiDim(Complex[] spectrum, int[] dimensions, FourierOptions options = FourierOptions.Default)
         {
             switch (options)
@@ -363,9 +674,50 @@ namespace MathNet.Numerics.IntegralTransforms
         /// <param name="columns">The number of columns.</param>
         /// <remarks>Data available organized column by column instead of row by row can be processed directly by swapping the rows and columns arguments.</remarks>
         /// <param name="options">Fourier Transform Convention Options.</param>
+        public static void Inverse2D(Complex32[] spectrumRowWise, int rows, int columns, FourierOptions options = FourierOptions.Default)
+        {
+            InverseMultiDim(spectrumRowWise, new[] { rows, columns }, options);
+        }
+
+        /// <summary>
+        /// Applies the inverse Fast Fourier Transform (iFFT) to two dimensional sample data.
+        /// </summary>
+        /// <param name="spectrumRowWise">Sample data, organized row by row, where the iFFT is evaluated in place</param>
+        /// <param name="rows">The number of rows.</param>
+        /// <param name="columns">The number of columns.</param>
+        /// <remarks>Data available organized column by column instead of row by row can be processed directly by swapping the rows and columns arguments.</remarks>
+        /// <param name="options">Fourier Transform Convention Options.</param>
         public static void Inverse2D(Complex[] spectrumRowWise, int rows, int columns, FourierOptions options = FourierOptions.Default)
         {
             InverseMultiDim(spectrumRowWise, new[] { rows, columns }, options);
+        }
+
+        /// <summary>
+        /// Applies the inverse Fast Fourier Transform (iFFT) to a two dimensional data in form of a matrix.
+        /// </summary>
+        /// <param name="spectrum">Sample matrix, where the iFFT is evaluated in place</param>
+        /// <param name="options">Fourier Transform Convention Options.</param>
+        public static void Inverse2D(Matrix<Complex32> spectrum, FourierOptions options = FourierOptions.Default)
+        {
+            var rowMajorArray = spectrum.AsRowMajorArray();
+            if (rowMajorArray != null)
+            {
+                InverseMultiDim(rowMajorArray, new[] { spectrum.RowCount, spectrum.ColumnCount }, options);
+                return;
+            }
+
+            var columnMajorArray = spectrum.AsColumnMajorArray();
+            if (columnMajorArray != null)
+            {
+                InverseMultiDim(columnMajorArray, new[] { spectrum.ColumnCount, spectrum.RowCount }, options);
+                return;
+            }
+
+            // Fall Back
+            columnMajorArray = spectrum.ToColumnMajorArray();
+            InverseMultiDim(columnMajorArray, new[] { spectrum.ColumnCount, spectrum.RowCount }, options);
+            var denseStorage = new DenseColumnMajorMatrixStorage<Complex32>(spectrum.RowCount, spectrum.ColumnCount, columnMajorArray);
+            denseStorage.CopyToUnchecked(spectrum.Storage, ExistingData.Clear);
         }
 
         /// <summary>
@@ -402,11 +754,37 @@ namespace MathNet.Numerics.IntegralTransforms
         /// <param name="samples">Time-space sample vector.</param>
         /// <param name="options">Fourier Transform Convention Options.</param>
         /// <returns>Corresponding frequency-space vector.</returns>
+        public static Complex32[] NaiveForward(Complex32[] samples, FourierOptions options = FourierOptions.Default)
+        {
+            var frequencySpace = Naive(samples, SignByOptions(options));
+            ForwardScaleByOptions(options, frequencySpace);
+            return frequencySpace;
+        }
+
+        /// <summary>
+        /// Naive forward DFT, useful e.g. to verify faster algorithms.
+        /// </summary>
+        /// <param name="samples">Time-space sample vector.</param>
+        /// <param name="options">Fourier Transform Convention Options.</param>
+        /// <returns>Corresponding frequency-space vector.</returns>
         public static Complex[] NaiveForward(Complex[] samples, FourierOptions options = FourierOptions.Default)
         {
             var frequencySpace = Naive(samples, SignByOptions(options));
             ForwardScaleByOptions(options, frequencySpace);
             return frequencySpace;
+        }
+
+        /// <summary>
+        /// Naive inverse DFT, useful e.g. to verify faster algorithms.
+        /// </summary>
+        /// <param name="spectrum">Frequency-space sample vector.</param>
+        /// <param name="options">Fourier Transform Convention Options.</param>
+        /// <returns>Corresponding time-space vector.</returns>
+        public static Complex32[] NaiveInverse(Complex32[] spectrum, FourierOptions options = FourierOptions.Default)
+        {
+            var timeSpace = Naive(spectrum, -SignByOptions(options));
+            InverseScaleByOptions(options, timeSpace);
+            return timeSpace;
         }
 
         /// <summary>
@@ -428,10 +806,34 @@ namespace MathNet.Numerics.IntegralTransforms
         /// <param name="samples">Sample vector, where the FFT is evaluated in place.</param>
         /// <param name="options">Fourier Transform Convention Options.</param>
         /// <exception cref="ArgumentException"/>
+        public static void Radix2Forward(Complex32[] samples, FourierOptions options = FourierOptions.Default)
+        {
+            Radix2Parallel(samples, SignByOptions(options));
+            ForwardScaleByOptions(options, samples);
+        }
+
+        /// <summary>
+        /// Radix-2 forward FFT for power-of-two sized sample vectors.
+        /// </summary>
+        /// <param name="samples">Sample vector, where the FFT is evaluated in place.</param>
+        /// <param name="options">Fourier Transform Convention Options.</param>
+        /// <exception cref="ArgumentException"/>
         public static void Radix2Forward(Complex[] samples, FourierOptions options = FourierOptions.Default)
         {
             Radix2Parallel(samples, SignByOptions(options));
             ForwardScaleByOptions(options, samples);
+        }
+
+        /// <summary>
+        /// Radix-2 inverse FFT for power-of-two sized sample vectors.
+        /// </summary>
+        /// <param name="spectrum">Sample vector, where the FFT is evaluated in place.</param>
+        /// <param name="options">Fourier Transform Convention Options.</param>
+        /// <exception cref="ArgumentException"/>
+        public static void Radix2Inverse(Complex32[] spectrum, FourierOptions options = FourierOptions.Default)
+        {
+            Radix2Parallel(spectrum, -SignByOptions(options));
+            InverseScaleByOptions(options, spectrum);
         }
 
         /// <summary>
@@ -451,10 +853,32 @@ namespace MathNet.Numerics.IntegralTransforms
         /// </summary>
         /// <param name="samples">Sample vector, where the FFT is evaluated in place.</param>
         /// <param name="options">Fourier Transform Convention Options.</param>
+        public static void BluesteinForward(Complex32[] samples, FourierOptions options = FourierOptions.Default)
+        {
+            Bluestein(samples, SignByOptions(options));
+            ForwardScaleByOptions(options, samples);
+        }
+
+        /// <summary>
+        /// Bluestein forward FFT for arbitrary sized sample vectors.
+        /// </summary>
+        /// <param name="samples">Sample vector, where the FFT is evaluated in place.</param>
+        /// <param name="options">Fourier Transform Convention Options.</param>
         public static void BluesteinForward(Complex[] samples, FourierOptions options = FourierOptions.Default)
         {
             Bluestein(samples, SignByOptions(options));
             ForwardScaleByOptions(options, samples);
+        }
+
+        /// <summary>
+        /// Bluestein inverse FFT for arbitrary sized sample vectors.
+        /// </summary>
+        /// <param name="spectrum">Sample vector, where the FFT is evaluated in place.</param>
+        /// <param name="options">Fourier Transform Convention Options.</param>
+        public static void BluesteinInverse(Complex32[] spectrum, FourierOptions options = FourierOptions.Default)
+        {
+            Bluestein(spectrum, -SignByOptions(options));
+            InverseScaleByOptions(options, spectrum);
         }
 
         /// <summary>
@@ -484,6 +908,26 @@ namespace MathNet.Numerics.IntegralTransforms
         /// </summary>
         /// <param name="options">Fourier Transform Convention Options.</param>
         /// <param name="samples">Sample Vector.</param>
+        static void ForwardScaleByOptions(FourierOptions options, Complex32[] samples)
+        {
+            if ((options & FourierOptions.NoScaling) == FourierOptions.NoScaling ||
+                (options & FourierOptions.AsymmetricScaling) == FourierOptions.AsymmetricScaling)
+            {
+                return;
+            }
+
+            var scalingFactor = (float)Math.Sqrt(1.0 / samples.Length);
+            for (int i = 0; i < samples.Length; i++)
+            {
+                samples[i] *= scalingFactor;
+            }
+        }
+
+        /// <summary>
+        /// Rescale FFT-the resulting vector according to the provided convention options.
+        /// </summary>
+        /// <param name="options">Fourier Transform Convention Options.</param>
+        /// <param name="samples">Sample Vector.</param>
         static void ForwardScaleByOptions(FourierOptions options, Complex[] samples)
         {
             if ((options & FourierOptions.NoScaling) == FourierOptions.NoScaling ||
@@ -493,6 +937,30 @@ namespace MathNet.Numerics.IntegralTransforms
             }
 
             var scalingFactor = Math.Sqrt(1.0/samples.Length);
+            for (int i = 0; i < samples.Length; i++)
+            {
+                samples[i] *= scalingFactor;
+            }
+        }
+
+        /// <summary>
+        /// Rescale the iFFT-resulting vector according to the provided convention options.
+        /// </summary>
+        /// <param name="options">Fourier Transform Convention Options.</param>
+        /// <param name="samples">Sample Vector.</param>
+        static void InverseScaleByOptions(FourierOptions options, Complex32[] samples)
+        {
+            if ((options & FourierOptions.NoScaling) == FourierOptions.NoScaling)
+            {
+                return;
+            }
+
+            var scalingFactor = (float)1.0 / samples.Length;
+            if ((options & FourierOptions.AsymmetricScaling) != FourierOptions.AsymmetricScaling)
+            {
+                scalingFactor = (float)Math.Sqrt(scalingFactor);
+            }
+
             for (int i = 0; i < samples.Length; i++)
             {
                 samples[i] *= scalingFactor;

--- a/src/Numerics/Providers/FourierTransform/IFourierTransformProvider.cs
+++ b/src/Numerics/Providers/FourierTransform/IFourierTransformProvider.cs
@@ -55,13 +55,19 @@ namespace MathNet.Numerics.Providers.FourierTransform
         /// </summary>
         void InitializeVerify();
 
+        void Forward(Complex32[] samples, FourierTransformScaling scaling);
         void Forward(Complex[] samples, FourierTransformScaling scaling);
+        void Backward(Complex32[] spectrum, FourierTransformScaling scaling);
         void Backward(Complex[] spectrum, FourierTransformScaling scaling);
-
+        
+        void ForwardReal(float[] samples, int n, FourierTransformScaling scaling);
         void ForwardReal(double[] samples, int n, FourierTransformScaling scaling);
+        void BackwardReal(float[] spectrum, int n, FourierTransformScaling scaling);
         void BackwardReal(double[] spectrum, int n, FourierTransformScaling scaling);
-
+        
+        void ForwardMultidim(Complex32[] samples, int[] dimensions, FourierTransformScaling scaling);
         void ForwardMultidim(Complex[] samples, int[] dimensions, FourierTransformScaling scaling);
+        void BackwardMultidim(Complex32[] spectrum, int[] dimensions, FourierTransformScaling scaling);
         void BackwardMultidim(Complex[] spectrum, int[] dimensions, FourierTransformScaling scaling);
     }
 }

--- a/src/UnitTests/IntegralTransformsTests/FourierTest.cs
+++ b/src/UnitTests/IntegralTransformsTests/FourierTest.cs
@@ -57,6 +57,41 @@ namespace MathNet.Numerics.UnitTests.IntegralTransformsTests
         /// Naive transforms real sine correctly.
         /// </summary>
         [Test]
+        public void NaiveTransformsRealSineCorrectly32()
+        {
+            var samples = Generate.PeriodicMap(16, w => new Complex32((float)Math.Sin(w), 0), 16, 1.0, Constants.Pi2);
+
+            // real-odd transforms to imaginary odd
+            var spectrum = Fourier.NaiveForward(samples, FourierOptions.Matlab);
+
+            // all real components must be zero
+            foreach (var c in spectrum)
+            {
+                Assert.AreEqual(0, c.Real, 1e-6, "real");
+            }
+
+            // all imaginary components except second and last musth be zero
+            for (var i = 0; i < spectrum.Length; i++)
+            {
+                if (i == 1)
+                {
+                    Assert.AreEqual(-8, spectrum[i].Imaginary, 1e-12, "imag second");
+                }
+                else if (i == spectrum.Length - 1)
+                {
+                    Assert.AreEqual(8, spectrum[i].Imaginary, 1e-12, "imag last");
+                }
+                else
+                {
+                    Assert.AreEqual(0, spectrum[i].Imaginary, 1e-6, "imag");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Naive transforms real sine correctly.
+        /// </summary>
+        [Test]
         public void NaiveTransformsRealSineCorrectly()
         {
             var samples = Generate.PeriodicMap(16, w => new Complex(Math.Sin(w), 0), 16, 1.0, Constants.Pi2);
@@ -86,6 +121,20 @@ namespace MathNet.Numerics.UnitTests.IntegralTransformsTests
                     Assert.AreEqual(0, spectrum[i].Imaginary, 1e-12, "imag");
                 }
             }
+        }
+
+        /// <summary>
+        /// Radix2XXX when not power of two throws <c>ArgumentException</c>.
+        /// </summary>
+        [Test]
+        public void Radix2ThrowsWhenNotPowerOfTwo32()
+        {
+            var samples = Generate.RandomComplex32(0x7F, GetUniform(1));
+
+            Assert.Throws(typeof(ArgumentException), () => Fourier.Radix2Forward(samples, FourierOptions.Default));
+            Assert.Throws(typeof(ArgumentException), () => Fourier.Radix2Inverse(samples, FourierOptions.Default));
+            Assert.Throws(typeof(ArgumentException), () => Fourier.Radix2(samples, -1));
+            Assert.Throws(typeof(ArgumentException), () => Fourier.Radix2Parallel(samples, -1));
         }
 
         /// <summary>

--- a/src/UnitTests/IntegralTransformsTests/InverseTransformTest.cs
+++ b/src/UnitTests/IntegralTransformsTests/InverseTransformTest.cs
@@ -58,6 +58,25 @@ namespace MathNet.Numerics.UnitTests.IntegralTransformsTests
         /// <param name="options">Fourier options.</param>
         [TestCase(FourierOptions.Default)]
         [TestCase(FourierOptions.Matlab)]
+        public void FourierNaiveIsReversible32(FourierOptions options)
+        {
+            var samples = Generate.RandomComplex32(0x80, GetUniform(1));
+            var work = new Complex32[samples.Length];
+            samples.CopyTo(work, 0);
+
+            work = Fourier.NaiveForward(work, options);
+            Assert.IsFalse(work.ListAlmostEqual(samples, 6));
+
+            work = Fourier.NaiveInverse(work, options);
+            AssertHelpers.AlmostEqual(samples, work, 11);
+        }
+
+        /// <summary>
+        /// Fourier naive is reversible.
+        /// </summary>
+        /// <param name="options">Fourier options.</param>
+        [TestCase(FourierOptions.Default)]
+        [TestCase(FourierOptions.Matlab)]
         public void FourierNaiveIsReversible(FourierOptions options)
         {
             var samples = Generate.RandomComplex(0x80, GetUniform(1));
@@ -68,6 +87,25 @@ namespace MathNet.Numerics.UnitTests.IntegralTransformsTests
             Assert.IsFalse(work.ListAlmostEqual(samples, 6));
 
             work = Fourier.NaiveInverse(work, options);
+            AssertHelpers.AlmostEqual(samples, work, 12);
+        }
+
+        /// <summary>
+        /// Fourier radix2xx is reversible.
+        /// </summary>
+        /// <param name="options">Fourier options.</param>
+        [TestCase(FourierOptions.Default)]
+        [TestCase(FourierOptions.Matlab)]
+        public void FourierRadix2IsReversible32(FourierOptions options)
+        {
+            var samples = Generate.RandomComplex32(0x8000, GetUniform(1));
+            var work = new Complex32[samples.Length];
+            samples.CopyTo(work, 0);
+
+            Fourier.Radix2Forward(work, options);
+            Assert.IsFalse(work.ListAlmostEqual(samples, 6));
+
+            Fourier.Radix2Inverse(work, options);
             AssertHelpers.AlmostEqual(samples, work, 12);
         }
 
@@ -96,6 +134,25 @@ namespace MathNet.Numerics.UnitTests.IntegralTransformsTests
         /// <param name="options">Fourier options.</param>
         [TestCase(FourierOptions.Default)]
         [TestCase(FourierOptions.Matlab)]
+        public void FourierBluesteinIsReversible32(FourierOptions options)
+        {
+            var samples = Generate.RandomComplex32(0x7FFF, GetUniform(1));
+            var work = new Complex32[samples.Length];
+            samples.CopyTo(work, 0);
+
+            Fourier.BluesteinForward(work, options);
+            Assert.IsFalse(work.ListAlmostEqual(samples, 6));
+
+            Fourier.BluesteinInverse(work, options);
+            AssertHelpers.AlmostEqual(samples, work, 10);
+        }
+
+        /// <summary>
+        /// Fourier bluestein is reversible.
+        /// </summary>
+        /// <param name="options">Fourier options.</param>
+        [TestCase(FourierOptions.Default)]
+        [TestCase(FourierOptions.Matlab)]
         public void FourierBluesteinIsReversible(FourierOptions options)
         {
             var samples = Generate.RandomComplex(0x7FFF, GetUniform(1));
@@ -107,6 +164,25 @@ namespace MathNet.Numerics.UnitTests.IntegralTransformsTests
 
             Fourier.BluesteinInverse(work, options);
             AssertHelpers.AlmostEqual(samples, work, 10);
+        }
+
+        /// <summary>
+        /// Fourier bluestein is reversible.
+        /// </summary>
+        /// <param name="options">Fourier options.</param>
+        [TestCase(FourierOptions.Default)]
+        [TestCase(FourierOptions.Matlab)]
+        public void FourierRealIsReversible32(FourierOptions options)
+        {
+            var samples = Generate.RandomSingle(0x7FFF, GetUniform(1));
+            var work = new float[samples.Length + 2];
+            samples.CopyTo(work, 0);
+
+            Fourier.ForwardReal(work, samples.Length, options);
+            Assert.IsFalse(work.ListAlmostEqual(samples, 6));
+
+            Fourier.InverseReal(work, samples.Length, options);
+            AssertHelpers.AlmostEqual(samples, work, 5);
         }
 
         /// <summary>
@@ -145,6 +221,29 @@ namespace MathNet.Numerics.UnitTests.IntegralTransformsTests
 
             work = Hartley.NaiveInverse(work, options);
             AssertHelpers.AlmostEqual(samples, work, 12);
+        }
+
+        /// <summary>
+        /// Fourier default transform is reversible.
+        /// </summary>
+        [Test]
+        public void FourierDefaultTransformIsReversible32()
+        {
+            var samples = Generate.RandomComplex32(0x7FFF, GetUniform(1));
+            var work = new Complex32[samples.Length];
+            samples.CopyTo(work, 0);
+
+            Fourier.Forward(work);
+            Assert.IsFalse(work.ListAlmostEqual(samples, 6));
+
+            Fourier.Inverse(work);
+            AssertHelpers.AlmostEqual(samples, work, 10);
+
+            Fourier.Inverse(work, FourierOptions.Default);
+            Assert.IsFalse(work.ListAlmostEqual(samples, 6));
+
+            Fourier.Forward(work, FourierOptions.Default);
+            AssertHelpers.AlmostEqual(samples, work, 10);
         }
 
         /// <summary>

--- a/src/UnitTests/IntegralTransformsTests/MatchingNaiveTransformTest.cs
+++ b/src/UnitTests/IntegralTransformsTests/MatchingNaiveTransformTest.cs
@@ -55,6 +55,22 @@ namespace MathNet.Numerics.UnitTests.IntegralTransformsTests
         }
 
         static void Verify(
+            Complex32[] samples,
+            int maximumErrorDecimalPlaces,
+            FourierOptions options,
+            Func<Complex32[], FourierOptions, Complex32[]> naive,
+            Action<Complex32[], FourierOptions> fast)
+        {
+            var spectrumNaive = naive(samples, options);
+
+            var spectrumFast = new Complex32[samples.Length];
+            samples.CopyTo(spectrumFast, 0);
+            fast(spectrumFast, options);
+
+            AssertHelpers.AlmostEqual(spectrumNaive, spectrumFast, maximumErrorDecimalPlaces);
+        }
+
+        static void Verify(
             Complex[] samples,
             int maximumErrorDecimalPlaces,
             FourierOptions options,
@@ -68,6 +84,24 @@ namespace MathNet.Numerics.UnitTests.IntegralTransformsTests
             fast(spectrumFast, options);
 
             AssertHelpers.AlmostEqual(spectrumNaive, spectrumFast, maximumErrorDecimalPlaces);
+        }
+
+        static void VerifyInplace(
+            Complex32[] samples,
+            int maximumErrorDecimalPlaces,
+            FourierOptions options,
+            Action<Complex32[], FourierOptions> expected,
+            Action<Complex32[], FourierOptions> actual)
+        {
+            var spectrumExpected = new Complex32[samples.Length];
+            samples.CopyTo(spectrumExpected, 0);
+            expected(spectrumExpected, options);
+
+            var spectrumActual = new Complex32[samples.Length];
+            samples.CopyTo(spectrumActual, 0);
+            actual(spectrumActual, options);
+
+            AssertHelpers.AlmostEqual(spectrumExpected, spectrumActual, maximumErrorDecimalPlaces);
         }
 
         static void VerifyInplace(
@@ -95,12 +129,42 @@ namespace MathNet.Numerics.UnitTests.IntegralTransformsTests
         [TestCase(FourierOptions.Default)]
         [TestCase(FourierOptions.Matlab)]
         [TestCase(FourierOptions.NumericalRecipes)]
+        public void FourierRadix2MatchesNaive_RealSine_32(FourierOptions options)
+        {
+            var samples = Generate.PeriodicMap(16, w => new Complex32((float)Math.Sin(w), 0), 16, 1.0, Constants.Pi2);
+
+            Verify(samples, 12, options, Fourier.NaiveForward, Fourier.Radix2Forward);
+            Verify(samples, 12, options, Fourier.NaiveInverse, Fourier.Radix2Inverse);
+        }
+
+        /// <summary>
+        /// Fourier Radix2XX matches naive on real sine.
+        /// </summary>
+        /// <param name="options">Fourier options.</param>
+        [TestCase(FourierOptions.Default)]
+        [TestCase(FourierOptions.Matlab)]
+        [TestCase(FourierOptions.NumericalRecipes)]
         public void FourierRadix2MatchesNaive_RealSine(FourierOptions options)
         {
             var samples = Generate.PeriodicMap(16, w => new Complex(Math.Sin(w), 0), 16, 1.0, Constants.Pi2);
 
             Verify(samples, 12, options, Fourier.NaiveForward, Fourier.Radix2Forward);
             Verify(samples, 12, options, Fourier.NaiveInverse, Fourier.Radix2Inverse);
+        }
+
+        /// <summary>
+        /// Fourier Radix2XX matches naive on random.
+        /// </summary>
+        /// <param name="options">Fourier options.</param>
+        [TestCase(FourierOptions.Default)]
+        [TestCase(FourierOptions.Matlab)]
+        [TestCase(FourierOptions.NumericalRecipes)]
+        public void FourierRadix2MatchesNaive_Random_32(FourierOptions options)
+        {
+            var samples = Generate.RandomComplex32(0x80, GetUniform(1));
+
+            Verify(samples, 10, options, Fourier.NaiveForward, Fourier.Radix2Forward);
+            Verify(samples, 10, options, Fourier.NaiveInverse, Fourier.Radix2Inverse);
         }
 
         /// <summary>
@@ -125,6 +189,21 @@ namespace MathNet.Numerics.UnitTests.IntegralTransformsTests
         [TestCase(FourierOptions.Default)]
         [TestCase(FourierOptions.Matlab)]
         [TestCase(FourierOptions.NumericalRecipes)]
+        public void FourierBluesteinMatchesNaive_RealSine_Arbitrary_32(FourierOptions options)
+        {
+            var samples = Generate.PeriodicMap(14, w => new Complex32((float)Math.Sin(w), 0), 14, 1.0, Constants.Pi2);
+
+            Verify(samples, 11, options, Fourier.NaiveForward, Fourier.BluesteinForward);
+            Verify(samples, 11, options, Fourier.NaiveInverse, Fourier.BluesteinInverse);
+        }
+
+        /// <summary>
+        /// Fourier bluestein matches naive on real sine non-power of two.
+        /// </summary>
+        /// <param name="options">Fourier options.</param>
+        [TestCase(FourierOptions.Default)]
+        [TestCase(FourierOptions.Matlab)]
+        [TestCase(FourierOptions.NumericalRecipes)]
         public void FourierBluesteinMatchesNaive_RealSine_Arbitrary(FourierOptions options)
         {
             var samples = Generate.PeriodicMap(14, w => new Complex(Math.Sin(w), 0), 14, 1.0, Constants.Pi2);
@@ -140,12 +219,42 @@ namespace MathNet.Numerics.UnitTests.IntegralTransformsTests
         [TestCase(FourierOptions.Default)]
         [TestCase(FourierOptions.Matlab)]
         [TestCase(FourierOptions.NumericalRecipes)]
+        public void FourierBluesteinMatchesNaive_Random_PowerOfTwo_32(FourierOptions options)
+        {
+            var samples = Generate.RandomComplex32(0x80, GetUniform(1));
+
+            Verify(samples, 10, options, Fourier.NaiveForward, Fourier.BluesteinForward);
+            Verify(samples, 10, options, Fourier.NaiveInverse, Fourier.BluesteinInverse);
+        }
+
+        /// <summary>
+        /// Fourier bluestein matches naive on random power of two.
+        /// </summary>
+        /// <param name="options">Fourier options.</param>
+        [TestCase(FourierOptions.Default)]
+        [TestCase(FourierOptions.Matlab)]
+        [TestCase(FourierOptions.NumericalRecipes)]
         public void FourierBluesteinMatchesNaive_Random_PowerOfTwo(FourierOptions options)
         {
             var samples = Generate.RandomComplex(0x80, GetUniform(1));
 
             Verify(samples, 10, options, Fourier.NaiveForward, Fourier.BluesteinForward);
             Verify(samples, 10, options, Fourier.NaiveInverse, Fourier.BluesteinInverse);
+        }
+
+        /// <summary>
+        /// Fourier bluestein matches naive on random non-power of two.
+        /// </summary>
+        /// <param name="options">Fourier options.</param>
+        [TestCase(FourierOptions.Default)]
+        [TestCase(FourierOptions.Matlab)]
+        [TestCase(FourierOptions.NumericalRecipes)]
+        public void FourierBluesteinMatchesNaive_Random_Arbitrary_32(FourierOptions options)
+        {
+            var samples = Generate.RandomComplex32(0x7F, GetUniform(1));
+
+            Verify(samples, 9, options, Fourier.NaiveForward, Fourier.BluesteinForward);
+            Verify(samples, 9, options, Fourier.NaiveInverse, Fourier.BluesteinInverse);
         }
 
         /// <summary>
@@ -173,12 +282,57 @@ namespace MathNet.Numerics.UnitTests.IntegralTransformsTests
         [TestCase(FourierOptions.InverseExponent)]
         [TestCase(FourierOptions.InverseExponent | FourierOptions.NoScaling)]
         [TestCase(FourierOptions.InverseExponent | FourierOptions.AsymmetricScaling)]
+        public void FourierBluesteinMatchesProvider_Random_Arbitrary_32(FourierOptions options)
+        {
+            var samples = Generate.RandomComplex32(0x7F, GetUniform(1));
+
+            VerifyInplace(samples, 10, options, Fourier.Forward, Fourier.BluesteinForward);
+            VerifyInplace(samples, 10, options, Fourier.Inverse, Fourier.BluesteinInverse);
+        }
+
+        /// <summary>
+        /// Fourier bluestein matches providers on random power of two.
+        /// </summary>
+        /// <param name="options">Fourier options.</param>
+        [TestCase(FourierOptions.Default)]
+        [TestCase(FourierOptions.NoScaling)]
+        [TestCase(FourierOptions.AsymmetricScaling)]
+        [TestCase(FourierOptions.InverseExponent)]
+        [TestCase(FourierOptions.InverseExponent | FourierOptions.NoScaling)]
+        [TestCase(FourierOptions.InverseExponent | FourierOptions.AsymmetricScaling)]
         public void FourierBluesteinMatchesProvider_Random_Arbitrary(FourierOptions options)
         {
             var samples = Generate.RandomComplex(0x7F, GetUniform(1));
 
             VerifyInplace(samples, 10, options, Fourier.Forward, Fourier.BluesteinForward);
             VerifyInplace(samples, 10, options, Fourier.Inverse, Fourier.BluesteinInverse);
+        }
+
+        [TestCase(FourierOptions.Default, 128)]
+        [TestCase(FourierOptions.Default, 129)]
+        [TestCase(FourierOptions.NoScaling, 128)]
+        [TestCase(FourierOptions.NoScaling, 129)]
+        [TestCase(FourierOptions.AsymmetricScaling, 128)]
+        [TestCase(FourierOptions.AsymmetricScaling, 129)]
+        public void RealMatchesComplex32(FourierOptions options, int n)
+        {
+            var real = Generate.RandomSingle(n.IsEven() ? n + 2 : n + 1, GetUniform(1));
+            real[n] = 0f;
+            if (n.IsEven()) real[n + 1] = 0f;
+            var complex = new Complex32[n];
+            for (int i = 0; i < complex.Length; i++)
+            {
+                complex[i] = new Complex32(real[i], 0f);
+            }
+
+            Fourier.Forward(complex, options);
+            Fourier.ForwardReal(real, n, options);
+
+            int m = (n + 1) / 2;
+            for (int i = 0, j = 0; i < m; i++)
+            {
+                AssertHelpers.AlmostEqual(complex[i], new Complex32(real[j++], real[j++]), 6);
+            }
         }
 
         [TestCase(FourierOptions.Default, 128)]
@@ -209,6 +363,16 @@ namespace MathNet.Numerics.UnitTests.IntegralTransformsTests
         }
 
         [Test]
+        public void AlgorithmsMatchProvider_PowerOfTwo_Large_32()
+        {
+            // 65536 = 2^16
+            var samples = Generate.RandomComplex32(65536, GetUniform(1));
+
+            VerifyInplace(samples, 10, FourierOptions.NoScaling, (s, o) => Control.FourierTransformProvider.Forward(s, FourierTransformScaling.NoScaling), Fourier.Radix2Forward);
+            VerifyInplace(samples, 10, FourierOptions.NoScaling, (s, o) => Control.FourierTransformProvider.Forward(s, FourierTransformScaling.NoScaling), Fourier.BluesteinForward);
+        }
+
+        [Test]
         public void AlgorithmsMatchProvider_PowerOfTwo_Large()
         {
             // 65536 = 2^16
@@ -219,6 +383,20 @@ namespace MathNet.Numerics.UnitTests.IntegralTransformsTests
         }
 
         [Test]
+        public void AlgorithmsMatchProvider_Arbitrary_Large_32()
+        {
+            // 30870 = 2*3*3*5*7*7*7
+            const FourierOptions options = FourierOptions.NoScaling;
+            var samples = Generate.RandomComplex32(30870, GetUniform(1));
+
+            var provider = new Complex32[samples.Length];
+            samples.Copy(provider);
+            Control.FourierTransformProvider.Forward(provider, FourierTransformScaling.NoScaling);
+
+            Verify(samples, 10, options, (a, b) => provider, Fourier.BluesteinForward);
+        }
+
+        [Test]
         public void AlgorithmsMatchProvider_Arbitrary_Large()
         {
             // 30870 = 2*3*3*5*7*7*7
@@ -226,6 +404,19 @@ namespace MathNet.Numerics.UnitTests.IntegralTransformsTests
             var samples = Generate.RandomComplex(30870, GetUniform(1));
 
             var provider = new Complex[samples.Length];
+            samples.Copy(provider);
+            Control.FourierTransformProvider.Forward(provider, FourierTransformScaling.NoScaling);
+
+            Verify(samples, 10, options, (a, b) => provider, Fourier.BluesteinForward);
+        }
+
+        [Test]
+        public void AlgorithmsMatchProvider_Arbitrary_Large_GH286_32()
+        {
+            const FourierOptions options = FourierOptions.NoScaling;
+            var samples = Generate.RandomComplex32(46500, GetUniform(1));
+
+            var provider = new Complex32[samples.Length];
             samples.Copy(provider);
             Control.FourierTransformProvider.Forward(provider, FourierTransformScaling.NoScaling);
 
@@ -246,6 +437,18 @@ namespace MathNet.Numerics.UnitTests.IntegralTransformsTests
         }
 
         [Test, Explicit("Long-Running")]
+        public void AlgorithmsMatchNaive_PowerOfTwo_Large_32()
+        {
+            // 65536 = 2^16
+            const FourierOptions options = FourierOptions.NoScaling;
+            var samples = Generate.RandomComplex32(65536, GetUniform(1));
+            var naive = Fourier.NaiveForward(samples, options);
+
+            Verify(samples, 3, options, (a, b) => naive, Fourier.Radix2Forward);
+            Verify(samples, 3, options, (a, b) => naive, Fourier.BluesteinForward);
+        }
+
+        [Test, Explicit("Long-Running")]
         public void AlgorithmsMatchNaive_PowerOfTwo_Large()
         {
             // 65536 = 2^16
@@ -258,6 +461,16 @@ namespace MathNet.Numerics.UnitTests.IntegralTransformsTests
         }
 
         [Test, Explicit("Long-Running")]
+        public void AlgorithmsMatchNaive_Arbitrary_Large_32()
+        {
+            // 30870 = 2*3*3*5*7*7*7
+            const FourierOptions options = FourierOptions.NoScaling;
+            var samples = Generate.RandomComplex32(30870, GetUniform(1));
+
+            Verify(samples, 4, options, Fourier.NaiveForward, Fourier.BluesteinForward);
+        }
+
+        [Test, Explicit("Long-Running")]
         public void AlgorithmsMatchNaive_Arbitrary_Large()
         {
             // 30870 = 2*3*3*5*7*7*7
@@ -266,6 +479,15 @@ namespace MathNet.Numerics.UnitTests.IntegralTransformsTests
             var naive = Fourier.NaiveForward(samples, options);
 
             Verify(samples, 10, options, (a, b) => naive, Fourier.BluesteinForward);
+        }
+
+        [Test, Explicit("Long-Running")]
+        public void AlgorithmsMatchNaive_Arbitrary_Large_GH286_32()
+        {
+            const FourierOptions options = FourierOptions.NoScaling;
+            var samples = Generate.RandomComplex32(46500, GetUniform(1));
+
+            Verify(samples, 4, options, Fourier.NaiveForward, Fourier.BluesteinForward);
         }
 
         [Test, Explicit("Long-Running")]

--- a/src/UnitTests/IntegralTransformsTests/ParsevalTheoremTest.cs
+++ b/src/UnitTests/IntegralTransformsTests/ParsevalTheoremTest.cs
@@ -60,6 +60,29 @@ namespace MathNet.Numerics.UnitTests.IntegralTransformsTests
         /// <param name="count">Samples count.</param>
         [TestCase(0x1000)]
         [TestCase(0x7FF)]
+        public void FourierDefaultTransformSatisfiesParsevalsTheorem32(int count)
+        {
+            var samples = Generate.RandomComplex32(count, GetUniform(1));
+
+            var timeSpaceEnergy = (from s in samples select s.MagnitudeSquared()).Mean();
+
+            var work = new Complex32[samples.Length];
+            samples.CopyTo(work, 0);
+
+            // Default -> Symmetric Scaling
+            Fourier.Forward(work);
+
+            var frequencySpaceEnergy = (from s in work select s.MagnitudeSquared()).Mean();
+
+            Assert.AreEqual(timeSpaceEnergy, frequencySpaceEnergy, 1e-7);
+        }
+
+        /// <summary>
+        /// Fourier default transform satisfies Parseval's theorem.
+        /// </summary>
+        /// <param name="count">Samples count.</param>
+        [TestCase(0x1000)]
+        [TestCase(0x7FF)]
         public void FourierDefaultTransformSatisfiesParsevalsTheorem(int count)
         {
             var samples = Generate.RandomComplex(count, GetUniform(1));


### PR DESCRIPTION
Duplicated existing double precision Fourier Transform code for single precision. This includes unit tests, managed provider and MKL provider. 