### PR TITLE
Handle combining empty running statistics

### DIFF
--- a/src/Numerics/Statistics/RunningStatistics.cs
+++ b/src/Numerics/Statistics/RunningStatistics.cs
@@ -237,6 +237,15 @@ namespace MathNet.Numerics.Statistics
         /// </summary>
         public static RunningStatistics Combine(RunningStatistics a, RunningStatistics b)
         {
+            if (a._n == 0)
+            {
+                return b;
+            }
+            else if (b._n == 0)
+            {
+                return a;
+            }
+            
             long n = a._n + b._n;
             double d = b._m1 - a._m1;
             double d2 = d*d;


### PR DESCRIPTION
This prevents most of the fields from being set to NaN when merging an empty instance.