### PR TITLE
Argument checks

### DIFF
--- a/src/Numerics/Distance.cs
+++ b/src/Numerics/Distance.cs
@@ -427,7 +427,7 @@ namespace MathNet.Numerics
                 throw new ArgumentException(Resources.ArgumentVectorsSameLength);
             }
 
-            if ((a.Length == 0 && b.Length == 0) || (a == null && b == null))
+            if (a.Length == 0 && b.Length == 0)
             {
                 return 0;
             }
@@ -473,7 +473,7 @@ namespace MathNet.Numerics
                 throw new ArgumentException(Resources.ArgumentVectorsSameLength);
             }
 
-            if ((a.Length == 0 && b.Length == 0) || (a == null && b == null))
+            if (a.Length == 0 && b.Length == 0)
             {
                 return 0;
             }

--- a/src/Numerics/Optimization/NelderMeadSimplex.cs
+++ b/src/Numerics/Optimization/NelderMeadSimplex.cs
@@ -113,7 +113,7 @@ namespace MathNet.Numerics.Optimization
             if (initialGuess == null)
                 throw new ArgumentNullException("initialGuess", "initialGuess must be initialized");
 
-            if (initialGuess == null)
+            if (initalPertubation == null)
                 throw new ArgumentNullException("initalPertubation", "initalPertubation must be initialized, if unknown use overloaded version of FindMinimum()");
 
             SimplexConstant[] simplexConstants = SimplexConstant.CreateSimplexConstantsFromVectors(initialGuess,initalPertubation);

--- a/src/Numerics/Providers/LinearAlgebra/ManagedLinearAlgebraProvider.Complex.cs
+++ b/src/Numerics/Providers/LinearAlgebra/ManagedLinearAlgebraProvider.Complex.cs
@@ -70,11 +70,6 @@ namespace MathNet.Numerics.Providers.LinearAlgebra
                 throw new ArgumentException(Resources.ArgumentVectorsSameLength);
             }
 
-            if (y.Length != x.Length)
-            {
-                throw new ArgumentException(Resources.ArgumentVectorsSameLength);
-            }
-
             if (alpha.IsZero())
             {
                 y.Copy(result);


### PR DESCRIPTION
`Jaccard` already throws if `a` or `b` is null, so no need to check them again.
And if the null initial null checks weren't there, `a.Length` or `b.Length` could throw an `NRE` before `(a == null && b == null)` was called

`Minimum` checked `initialGuess` twice instead of checking `initalPertubation`.

`AddVectorToScaledVector` checked `if (y.Length != x.Length)` twice.