### PR TITLE
Initialize list with known capacity

### DIFF
--- a/src/Numerics/LinearAlgebra/Complex/Solvers/MlkBiCgStab.cs
+++ b/src/Numerics/LinearAlgebra/Complex/Solvers/MlkBiCgStab.cs
@@ -193,7 +193,7 @@ namespace MathNet.Numerics.LinearAlgebra.Complex.Solvers
             var orthogonalMatrix = gs.Q;
 
             // Now transfer this to vectors
-            var result = new List<Vector<Complex>>();
+            var result = new List<Vector<Complex>>(orthogonalMatrix.ColumnCount);
             for (var i = 0; i < orthogonalMatrix.ColumnCount; i++)
             {
                 result.Add(orthogonalMatrix.Column(i));

--- a/src/Numerics/LinearAlgebra/Complex32/Solvers/MlkBiCgStab.cs
+++ b/src/Numerics/LinearAlgebra/Complex32/Solvers/MlkBiCgStab.cs
@@ -186,7 +186,7 @@ namespace MathNet.Numerics.LinearAlgebra.Complex32.Solvers
             var orthogonalMatrix = gs.Q;
 
             // Now transfer this to vectors
-            var result = new List<Vector<Numerics.Complex32>>();
+            var result = new List<Vector<Numerics.Complex32>>(orthogonalMatrix.ColumnCount);
             for (var i = 0; i < orthogonalMatrix.ColumnCount; i++)
             {
                 result.Add(orthogonalMatrix.Column(i));

--- a/src/Numerics/LinearAlgebra/Double/Solvers/MlkBiCgStab.cs
+++ b/src/Numerics/LinearAlgebra/Double/Solvers/MlkBiCgStab.cs
@@ -186,7 +186,7 @@ namespace MathNet.Numerics.LinearAlgebra.Double.Solvers
             var orthogonalMatrix = gs.Q;
 
             // Now transfer this to vectors
-            var result = new List<Vector<double>>();
+            var result = new List<Vector<double>>(orthogonalMatrix.ColumnCount);
             for (var i = 0; i < orthogonalMatrix.ColumnCount; i++)
             {
                 result.Add(orthogonalMatrix.Column(i));

--- a/src/Numerics/LinearAlgebra/Single/Solvers/MlkBiCgStab.cs
+++ b/src/Numerics/LinearAlgebra/Single/Solvers/MlkBiCgStab.cs
@@ -189,7 +189,7 @@ namespace MathNet.Numerics.LinearAlgebra.Single.Solvers
             var orthogonalMatrix = gs.Q;
 
             // Now transfer this to vectors
-            var result = new List<Vector<float>>();
+            var result = new List<Vector<float>>(orthogonalMatrix.ColumnCount);
             for (var i = 0; i < orthogonalMatrix.ColumnCount; i++)
             {
                 result.Add(orthogonalMatrix.Column(i));


### PR DESCRIPTION
This uses the capacity overload of the `List` constructor as we know that `orthogonalMatrix.ColumnCount` entries will be inserted.