### PR TITLE
SparseMatrix implementation of DoTransposeThisAndMultiply

### DIFF
--- a/src/Numerics/LinearAlgebra/Complex/SparseMatrix.cs
+++ b/src/Numerics/LinearAlgebra/Complex/SparseMatrix.cs
@@ -1146,6 +1146,35 @@ namespace MathNet.Numerics.LinearAlgebra.Complex
         }
 
         /// <summary>
+        /// Multiplies the transpose of this matrix with a vector and places the results into the result vector.
+        /// </summary>
+        /// <param name="rightSide">The vector to multiply with.</param>
+        /// <param name="result">The result of the multiplication.</param>
+        protected override void DoTransposeThisAndMultiply(Vector<Complex> rightSide, Vector<Complex> result)
+        {
+            var rowPointers = _storage.RowPointers;
+            var columnIndices = _storage.ColumnIndices;
+            var values = _storage.Values;
+
+            for (var row = 0; row < RowCount; row++)
+            {
+                var startIndex = rowPointers[row];
+                var endIndex = rowPointers[row + 1];
+
+                if (startIndex == endIndex)
+                {
+                    continue;
+                }
+
+                var rightSideValue = rightSide[row];
+                for (var index = startIndex; index < endIndex; index++)
+                {
+                    result[columnIndices[index]] += values[index] * rightSideValue;
+                }
+            }
+        }
+
+        /// <summary>
         /// Pointwise multiplies this matrix with another matrix and stores the result into the result matrix.
         /// </summary>
         /// <param name="other">The matrix to pointwise multiply with this one.</param>

--- a/src/Numerics/LinearAlgebra/Complex32/SparseMatrix.cs
+++ b/src/Numerics/LinearAlgebra/Complex32/SparseMatrix.cs
@@ -1145,6 +1145,35 @@ namespace MathNet.Numerics.LinearAlgebra.Complex32
         }
 
         /// <summary>
+        /// Multiplies the transpose of this matrix with a vector and places the results into the result vector.
+        /// </summary>
+        /// <param name="rightSide">The vector to multiply with.</param>
+        /// <param name="result">The result of the multiplication.</param>
+        protected override void DoTransposeThisAndMultiply(Vector<Complex32> rightSide, Vector<Complex32> result)
+        {
+            var rowPointers = _storage.RowPointers;
+            var columnIndices = _storage.ColumnIndices;
+            var values = _storage.Values;
+
+            for (var row = 0; row < RowCount; row++)
+            {
+                var startIndex = rowPointers[row];
+                var endIndex = rowPointers[row + 1];
+
+                if (startIndex == endIndex)
+                {
+                    continue;
+                }
+
+                var rightSideValue = rightSide[row];
+                for (var index = startIndex; index < endIndex; index++)
+                {
+                    result[columnIndices[index]] += values[index] * rightSideValue;
+                }
+            }
+        }
+
+        /// <summary>
         /// Pointwise multiplies this matrix with another matrix and stores the result into the result matrix.
         /// </summary>
         /// <param name="other">The matrix to pointwise multiply with this one.</param>

--- a/src/Numerics/LinearAlgebra/Double/SparseMatrix.cs
+++ b/src/Numerics/LinearAlgebra/Double/SparseMatrix.cs
@@ -1143,6 +1143,35 @@ namespace MathNet.Numerics.LinearAlgebra.Double
         }
 
         /// <summary>
+        /// Multiplies the transpose of this matrix with a vector and places the results into the result vector.
+        /// </summary>
+        /// <param name="rightSide">The vector to multiply with.</param>
+        /// <param name="result">The result of the multiplication.</param>
+        protected override void DoTransposeThisAndMultiply(Vector<double> rightSide, Vector<double> result)
+        {
+            var rowPointers = _storage.RowPointers;
+            var columnIndices = _storage.ColumnIndices;
+            var values = _storage.Values;
+
+            for (var row = 0; row < RowCount; row++)
+            {
+                var startIndex = rowPointers[row];
+                var endIndex = rowPointers[row + 1];
+
+                if (startIndex == endIndex)
+                {
+                    continue;
+                }
+
+                var rightSideValue = rightSide[row];
+                for (var index = startIndex; index < endIndex; index++)
+                {
+                    result[columnIndices[index]] += values[index] * rightSideValue;
+                }
+            }
+        }
+
+        /// <summary>
         /// Pointwise multiplies this matrix with another matrix and stores the result into the result matrix.
         /// </summary>
         /// <param name="other">The matrix to pointwise multiply with this one.</param>

--- a/src/Numerics/LinearAlgebra/Single/SparseMatrix.cs
+++ b/src/Numerics/LinearAlgebra/Single/SparseMatrix.cs
@@ -1148,6 +1148,35 @@ namespace MathNet.Numerics.LinearAlgebra.Single
         }
 
         /// <summary>
+        /// Multiplies the transpose of this matrix with a vector and places the results into the result vector.
+        /// </summary>
+        /// <param name="rightSide">The vector to multiply with.</param>
+        /// <param name="result">The result of the multiplication.</param>
+        protected override void DoTransposeThisAndMultiply(Vector<float> rightSide, Vector<float> result)
+        {
+            var rowPointers = _storage.RowPointers;
+            var columnIndices = _storage.ColumnIndices;
+            var values = _storage.Values;
+
+            for (var row = 0; row < RowCount; row++)
+            {
+                var startIndex = rowPointers[row];
+                var endIndex = rowPointers[row + 1];
+
+                if (startIndex == endIndex)
+                {
+                    continue;
+                }
+
+                var rightSideValue = rightSide[row];
+                for (var index = startIndex; index < endIndex; index++)
+                {
+                    result[columnIndices[index]] += values[index] * rightSideValue;
+                }
+            }
+        }
+
+        /// <summary>
         /// Pointwise multiplies this matrix with another matrix and stores the result into the result matrix.
         /// </summary>
         /// <param name="other">The matrix to pointwise multiply with this one.</param>


### PR DESCRIPTION
Addition of a SparseMatrix implementation of DoTransposeThisAndMultiply(Vector<type> rightSide, Vector<type> result), for Double, Single, Complex and Complex32 types.

This change is to address the performance issue identified and discussed in issue #573. 