### PR TITLE
Issue 632, NelderMeadSimplex Does Not Always Return Best Evaluated Point

### DIFF
--- a/src/Numerics/Optimization/NelderMeadSimplex.cs
+++ b/src/Numerics/Optimization/NelderMeadSimplex.cs
@@ -173,6 +173,7 @@ namespace MathNet.Numerics.Optimization
                     throw new MaximumIterationsException(String.Format("Maximum iterations ({0}) reached.", maximumIterations));
                 }
             }
+            objectiveFunction.EvaluateAt(vertices[errorProfile.LowestIndex]);
             var regressionResult = new MinimizationResult(objectiveFunction, evaluationCount, exitCondition);
             return regressionResult;
         }


### PR DESCRIPTION
Immediately prior to completion, re-evaluate objective function with best vertex to set proper state.