### PR TITLE
Add support for multivariate nonlinear regression

### DIFF
--- a/src/Numerics/Optimization/ObjectiveFunction.cs
+++ b/src/Numerics/Optimization/ObjectiveFunction.cs
@@ -28,6 +28,7 @@
 // </copyright>
 
 using System;
+using System.Linq;
 using MathNet.Numerics.LinearAlgebra;
 using MathNet.Numerics.Optimization.ObjectiveFunctions;
 
@@ -217,6 +218,130 @@ namespace MathNet.Numerics.Optimization
             int accuracyOrder = 2)
         {
             var objective = new NonlinearObjectiveFunction(function, null, accuracyOrder: accuracyOrder);
+            objective.SetObserved(observedX, observedY, weight);
+            return objective.ToObjectiveFunction();
+        }
+
+        /// <summary>
+        /// objective model with a user supplied jacobian for multivariate non-linear least squares regression.
+        /// </summary>
+        public static IObjectiveModel MultivariateNonlinearModel(
+            Func<Vector<double>, Vector<double>[], Vector<double>> function,
+            Func<Vector<double>, Vector<double>[], Matrix<double>> derivatives,
+            Vector<double>[] observedX,
+            Vector<double> observedY,
+            Vector<double> weight = null)
+        {
+            var objective = new MultivariateNonlinearObjectiveFunction(function, derivatives);
+            objective.SetObserved(observedX, observedY, weight);
+            return objective;
+        }
+
+        /// <summary>
+        /// Objective model for multivariate non-linear least squares regression.
+        /// </summary>
+        public static IObjectiveModel MultivariateNonlinearModel(
+            Func<Vector<double>, Vector<double>[], Vector<double>> function,
+            Vector<double>[] observedX,
+            Vector<double> observedY,
+            Vector<double> weight = null,
+            int accuracyOrder = 2)
+        {
+            var objective = new MultivariateNonlinearObjectiveFunction(function, accuracyOrder: accuracyOrder);
+            objective.SetObserved(observedX, observedY, weight);
+            return objective;
+        }
+
+        /// <summary>
+        /// Objective model with a user supplied jacobian for multivariate non-linear least squares regression.
+        /// </summary>
+        public static IObjectiveModel MultivariateNonlinearModel(
+            Func<Vector<double>, double[], double> function,
+            Func<Vector<double>, double[], Vector<double>> derivatives,
+            Vector<double>[] observedX,
+            Vector<double> observedY,
+            Vector<double> weight = null)
+        {
+            Vector<double> func(Vector<double> point, Vector<double>[] x)
+            {
+                var functionValues = CreateVector.Dense<double>(x[0].Count);
+                for (int i = 0; i < x[0].Count; i++)
+                {
+                    functionValues[i] = function(point, x.Select(_ => _[i]).ToArray());
+                }
+
+                return functionValues;
+            }
+
+            Matrix<double> prime(Vector<double> point, Vector<double>[] x)
+            {
+                var derivativeValues = CreateMatrix.Dense<double>(x[0].Count, point.Count);
+                for (int i = 0; i < x[0].Count; i++)
+                {
+                    derivativeValues.SetRow(i, derivatives(point, x.Select(_ => _[i]).ToArray()));
+                }
+
+                return derivativeValues;
+            }
+
+            var objective = new MultivariateNonlinearObjectiveFunction(func, prime);
+            objective.SetObserved(observedX, observedY, weight);
+            return objective;
+        }
+
+        /// <summary>
+        /// Objective model for non-linear least squares regression.
+        /// </summary>
+        public static IObjectiveModel MultivariateNonlinearModel(
+            Func<Vector<double>, double[], double> function,
+            Vector<double>[] observedX,
+            Vector<double> observedY,
+            Vector<double> weight = null,
+            int accuracyOrder = 2)
+        {
+            Vector<double> func(Vector<double> point, Vector<double>[] x)
+            {
+                var functionValues = CreateVector.Dense<double>(x[0].Count);
+                for (int i = 0; i < x[0].Count; i++)
+                {
+                    functionValues[i] = function(point, x.Select(_ => _[i]).ToArray());
+                }
+
+                return functionValues;
+            }
+
+            var objective = new MultivariateNonlinearObjectiveFunction(func, accuracyOrder: accuracyOrder);
+            objective.SetObserved(observedX, observedY, weight);
+            return objective;
+        }
+
+        /// <summary>
+        /// Objective function with a user supplied jacobian for multivaraite non-linear least squares regression.
+        /// </summary>
+        public static IObjectiveFunction MultivariateNonlinearFunction(
+            Func<Vector<double>, Vector<double>[], Vector<double>> function,
+            Func<Vector<double>, Vector<double>[], Matrix<double>> derivatives,
+            Vector<double>[] observedX,
+            Vector<double> observedY,
+            Vector<double> weight = null)
+        {
+            var objective = new MultivariateNonlinearObjectiveFunction(function, derivatives);
+            objective.SetObserved(observedX, observedY, weight);
+            return objective.ToObjectiveFunction();
+        }
+
+        /// <summary>
+        /// Objective function for multivariate non-linear least squares regression.
+        /// The numerical jacobian with accuracy order is used.
+        /// </summary>
+        public static IObjectiveFunction MultivariateNonlinearFunction(
+            Func<Vector<double>, Vector<double>[], Vector<double>> function,
+            Vector<double>[] observedX,
+            Vector<double> observedY,
+            Vector<double> weight = null,
+            int accuracyOrder = 2)
+        {
+            var objective = new MultivariateNonlinearObjectiveFunction(function, null, accuracyOrder: accuracyOrder);
             objective.SetObserved(observedX, observedY, weight);
             return objective.ToObjectiveFunction();
         }


### PR DESCRIPTION
Extend fitting to include support for multivariate models.

I added `ObjectiveFunction.MultivariateNonlinearModel` so that fitting could be done with multidimensional models such a 2D circle.