### PR TITLE
Ensure Hypergeometric.CDF <= 1.0 (Issue #679)

### DIFF
--- a/src/Numerics/Distributions/Hypergeometric.cs
+++ b/src/Numerics/Distributions/Hypergeometric.cs
@@ -315,7 +315,7 @@ namespace MathNet.Numerics.Distributions
                 sum += Math.Exp(SpecialFunctions.BinomialLn(success, i) + SpecialFunctions.BinomialLn(population - success, draws - i) - denominatorLn);
             }
 
-            return sum;
+            return Math.Min(sum, 1.0);
         }
 
         /// <summary>


### PR DESCRIPTION
This is, to be fair, a kludge -- it would be more efficient to ensure that such a situation can never arise in the first place. Proposed as a temporary(?) solution to issue #679