### PR TITLE
Tests for Moore-Penrose Pseudo-Inverse and bugfix for Pseudo-Inverse of complex matrices

### DIFF
--- a/src/Numerics.Tests/LinearAlgebraTests/Complex/MatrixTests.Arithmetic.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Complex/MatrixTests.Arithmetic.cs
@@ -820,6 +820,20 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Complex
         }
 
         /// <summary>
+        /// Can compute Moore-Penrose Pseudo-Inverse.
+        /// </summary>
+        [TestCase("Square3x3")]
+        [TestCase("Wide2x3")]
+        [TestCase("Tall3x2")]
+        public virtual void CanComputePseudoInverse(string name)
+        {
+            var matrix = TestMatrices[name];
+            var inverse = matrix.PseudoInverse();
+            // Testing for Moore–Penrose conditions 1: A*A^+*A = A
+            AssertHelpers.AlmostEqual(matrix, matrix * inverse * matrix, 12);
+        }
+
+        /// <summary>
         /// Can calculate Kronecker product.
         /// </summary>
         [Test]

--- a/src/Numerics.Tests/LinearAlgebraTests/Complex32/Factorization/SvdTests.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Complex32/Factorization/SvdTests.cs
@@ -75,6 +75,52 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Complex32.Factorization
             }
         }
 
+
+        [Test]
+        public void CanFactorizeSpecialMatrix()
+        {
+            int row = 7;
+            int column = 7;
+            Complex32[,] data =
+            {
+                {new Complex32(0.999967f, -0.00816902f), new Complex32(0.999999f, 0.00142905f), new Complex32(0.999994f, -0.00341607f), new Complex32(1f, 0f), new Complex32(0.999994f, 0.00341607f), new Complex32(0.999999f, -0.00142905f), new Complex32(0.999967f, 0.00816902f)},
+                {new Complex32(0.617082f, -0.786899f), new Complex32(-0.221127f, -0.975245f), new Complex32(-0.902446f, -0.430804f), new Complex32(1f, 0f), new Complex32(-0.902446f, 0.430804f), new Complex32(-0.221127f, 0.975245f), new Complex32(0.617082f, 0.786899f)},
+                {new Complex32(-0.230478f, -0.973078f), new Complex32(-0.901588f, 0.432596f), new Complex32(0.626157f, 0.779697f), new Complex32(1f, 0f), new Complex32(0.626157f, -0.779697f), new Complex32(-0.901588f, -0.432596f), new Complex32(-0.230478f, 0.973078f)},
+                {new Complex32(-0.904483f, -0.426509f), new Complex32(0.622372f, 0.782722f), new Complex32(-0.22585f, -0.974162f), new Complex32(1f, 0f), new Complex32(-0.22585f, 0.974162f), new Complex32(0.622372f, -0.782722f), new Complex32(-0.904483f, 0.426509f)},
+                {new Complex32(-0.897394f, 0.441229f), new Complex32(0.624607f, -0.780939f), new Complex32(-0.21919f, 0.975682f), new Complex32(1f, 0f), new Complex32(-0.21919f, -0.975682f), new Complex32(0.624607f, 0.780939f), new Complex32(-0.897394f, -0.441229f)},
+                {new Complex32(-0.214549f, 0.976713f), new Complex32(-0.900348f, -0.435171f), new Complex32(0.620816f, -0.783957f), new Complex32(1f, 0f), new Complex32(0.620816f, 0.783957f), new Complex32(-0.900348f, 0.435171f), new Complex32(-0.214549f, -0.976713f)},
+                {new Complex32(0.629856f, 0.776712f), new Complex32(-0.223914f, 0.974609f), new Complex32(-0.899482f, 0.436958f), new Complex32(1f, 0f), new Complex32(-0.899482f, -0.436958f), new Complex32(-0.223914f, -0.974609f), new Complex32(0.629856f, -0.776712f)}
+            };
+            var matrixA = DenseMatrix.Create(7, 7, (r, c) => data[c, r]);
+            var factorSvd = matrixA.Svd();
+            var u = factorSvd.U;
+            var vt = factorSvd.VT;
+            var w = factorSvd.W;
+
+            // Make sure the U has the right dimensions.
+            Assert.AreEqual(row, u.RowCount);
+            Assert.AreEqual(row, u.ColumnCount);
+
+            // Make sure the VT has the right dimensions.
+            Assert.AreEqual(column, vt.RowCount);
+            Assert.AreEqual(column, vt.ColumnCount);
+
+            // Make sure the W has the right dimensions.
+            Assert.AreEqual(row, w.RowCount);
+            Assert.AreEqual(column, w.ColumnCount);
+
+            // Make sure the U*W*VT is the original matrix.
+            var matrix = u*w*vt;
+            for (var i = 0; i < matrix.RowCount; i++)
+            {
+                for (var j = 0; j < matrix.ColumnCount; j++)
+                {
+                    Assert.AreEqual(matrixA[i, j].Real, matrix[i, j].Real, 1e-3f);
+                    Assert.AreEqual(matrixA[i, j].Imaginary, matrix[i, j].Imaginary, 1e-3f);
+                }
+            }
+        }
+
         /// <summary>
         /// Can factorize a random matrix.
         /// </summary>

--- a/src/Numerics.Tests/LinearAlgebraTests/Complex32/MatrixTests.Arithmetic.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Complex32/MatrixTests.Arithmetic.cs
@@ -821,6 +821,20 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Complex32
         }
 
         /// <summary>
+        /// Can compute Moore-Penrose Pseudo-Inverse.
+        /// </summary>
+        [TestCase("Square3x3")]
+        [TestCase("Wide2x3")]
+        [TestCase("Tall3x2")]
+        public virtual void CanComputePseudoInverse(string name)
+        {
+            var matrix = TestMatrices[name];
+            var inverse = matrix.PseudoInverse();
+            // Testing for Moore–Penrose conditions 1: A*A^+*A = A
+            AssertHelpers.AlmostEqual(matrix, matrix * inverse * matrix, 5);
+        }
+
+        /// <summary>
         /// Can calculate Kronecker product.
         /// </summary>
         [Test]

--- a/src/Numerics.Tests/LinearAlgebraTests/Double/MatrixTests.Arithmetic.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Double/MatrixTests.Arithmetic.cs
@@ -814,6 +814,20 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Double
         }
 
         /// <summary>
+        /// Can compute Moore-Penrose Pseudo-Inverse.
+        /// </summary>
+        [TestCase("Square3x3")]
+        [TestCase("Wide2x3")]
+        [TestCase("Tall3x2")]
+        public virtual void CanComputePseudoInverse(string name)
+        {
+            var matrix = TestMatrices[name];
+            var inverse = matrix.PseudoInverse();
+            // Testing for Moore–Penrose conditions 1: A*A^+*A = A
+            AssertHelpers.AlmostEqual(matrix, matrix * inverse * matrix, 12);
+        }
+
+        /// <summary>
         /// Can calculate Kronecker product.
         /// </summary>
         [Test]

--- a/src/Numerics.Tests/LinearAlgebraTests/Single/MatrixTests.Arithmetic.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Single/MatrixTests.Arithmetic.cs
@@ -809,6 +809,20 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Single
         }
 
         /// <summary>
+        /// Can compute Moore-Penrose Pseudo-Inverse.
+        /// </summary>
+        [TestCase("Square3x3")]
+        [TestCase("Wide2x3")]
+        [TestCase("Tall3x2")]
+        public virtual void CanComputePseudoInverse(string name)
+        {
+            var matrix = TestMatrices[name];
+            var inverse = matrix.PseudoInverse();
+            // Testing for Moore–Penrose conditions 1: A*A^+*A = A
+            AssertHelpers.AlmostEqual(matrix, matrix * inverse * matrix, 5);
+        }
+
+        /// <summary>
         /// Can calculate Kronecker product.
         /// </summary>
         [Test]

--- a/src/Numerics/LinearAlgebra/Complex/Matrix.cs
+++ b/src/Numerics/LinearAlgebra/Complex/Matrix.cs
@@ -539,7 +539,7 @@ namespace MathNet.Numerics.LinearAlgebra.Complex
             }
 
             w.SetDiagonal(s);
-            return (svd.U * w * svd.VT).Transpose();
+            return (svd.U * w * svd.VT).ConjugateTranspose();
         }
 
         /// <summary>

--- a/src/Numerics/LinearAlgebra/Complex32/Matrix.cs
+++ b/src/Numerics/LinearAlgebra/Complex32/Matrix.cs
@@ -539,7 +539,7 @@ namespace MathNet.Numerics.LinearAlgebra.Complex32
             }
 
             w.SetDiagonal(s);
-            return (svd.U * w * svd.VT).Transpose();
+            return (svd.U * w * svd.VT).ConjugateTranspose();
         }
 
         /// <summary>


### PR DESCRIPTION
Moore-Penrose Pseudo-Inverse currently gives wrong results for complex matrices. This PR adds tests for Pseudo-Inverses and fixes the implementation for complex matrices.

The tests fails for DiagonalMatrix because there seems to be a bug in the multiplication of non square diagonal matrices with sparse matrices. Unfortunately I am not able to fix this bug. 