### PR TITLE
Tests for Moore-Penrose Pseudo-Inverse and bugfix for Pseudo-Inverse of complex matrices

### DIFF
--- a/src/Numerics.Tests/LinearAlgebraTests/Complex/MatrixTests.Arithmetic.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Complex/MatrixTests.Arithmetic.cs
@@ -820,6 +820,20 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Complex
         }
 
         /// <summary>
+        /// Can compute Moore-Penrose Pseudo-Inverse.
+        /// </summary>
+        [TestCase("Square3x3")]
+        [TestCase("Wide2x3")]
+        [TestCase("Tall3x2")]
+        public virtual void CanComputePseudoInverse(string name)
+        {
+            var matrix = TestMatrices[name];
+            var inverse = matrix.PseudoInverse();
+            // Testing for Moore–Penrose conditions 1: A*A^+*A = A
+            AssertHelpers.AlmostEqual(matrix, matrix * inverse * matrix, 12);
+        }
+
+        /// <summary>
         /// Can calculate Kronecker product.
         /// </summary>
         [Test]

--- a/src/Numerics.Tests/LinearAlgebraTests/Complex32/MatrixTests.Arithmetic.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Complex32/MatrixTests.Arithmetic.cs
@@ -821,6 +821,20 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Complex32
         }
 
         /// <summary>
+        /// Can compute Moore-Penrose Pseudo-Inverse.
+        /// </summary>
+        [TestCase("Square3x3")]
+        [TestCase("Wide2x3")]
+        [TestCase("Tall3x2")]
+        public virtual void CanComputePseudoInverse(string name)
+        {
+            var matrix = TestMatrices[name];
+            var inverse = matrix.PseudoInverse();
+            // Testing for Moore–Penrose conditions 1: A*A^+*A = A
+            AssertHelpers.AlmostEqual(matrix, matrix * inverse * matrix, 5);
+        }
+
+        /// <summary>
         /// Can calculate Kronecker product.
         /// </summary>
         [Test]

--- a/src/Numerics.Tests/LinearAlgebraTests/Double/MatrixTests.Arithmetic.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Double/MatrixTests.Arithmetic.cs
@@ -814,6 +814,20 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Double
         }
 
         /// <summary>
+        /// Can compute Moore-Penrose Pseudo-Inverse.
+        /// </summary>
+        [TestCase("Square3x3")]
+        [TestCase("Wide2x3")]
+        [TestCase("Tall3x2")]
+        public virtual void CanComputePseudoInverse(string name)
+        {
+            var matrix = TestMatrices[name];
+            var inverse = matrix.PseudoInverse();
+            // Testing for Moore–Penrose conditions 1: A*A^+*A = A
+            AssertHelpers.AlmostEqual(matrix, matrix * inverse * matrix, 12);
+        }
+
+        /// <summary>
         /// Can calculate Kronecker product.
         /// </summary>
         [Test]

--- a/src/Numerics.Tests/LinearAlgebraTests/Single/MatrixTests.Arithmetic.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Single/MatrixTests.Arithmetic.cs
@@ -809,6 +809,20 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Single
         }
 
         /// <summary>
+        /// Can compute Moore-Penrose Pseudo-Inverse.
+        /// </summary>
+        [TestCase("Square3x3")]
+        [TestCase("Wide2x3")]
+        [TestCase("Tall3x2")]
+        public virtual void CanComputePseudoInverse(string name)
+        {
+            var matrix = TestMatrices[name];
+            var inverse = matrix.PseudoInverse();
+            // Testing for Moore–Penrose conditions 1: A*A^+*A = A
+            AssertHelpers.AlmostEqual(matrix, matrix * inverse * matrix, 5);
+        }
+
+        /// <summary>
         /// Can calculate Kronecker product.
         /// </summary>
         [Test]

--- a/src/Numerics/LinearAlgebra/Complex/Matrix.cs
+++ b/src/Numerics/LinearAlgebra/Complex/Matrix.cs
@@ -539,7 +539,7 @@ namespace MathNet.Numerics.LinearAlgebra.Complex
             }
 
             w.SetDiagonal(s);
-            return (svd.U * w * svd.VT).Transpose();
+            return (svd.U * w * svd.VT).ConjugateTranspose();
         }
 
         /// <summary>

--- a/src/Numerics/LinearAlgebra/Complex32/Matrix.cs
+++ b/src/Numerics/LinearAlgebra/Complex32/Matrix.cs
@@ -539,7 +539,7 @@ namespace MathNet.Numerics.LinearAlgebra.Complex32
             }
 
             w.SetDiagonal(s);
-            return (svd.U * w * svd.VT).Transpose();
+            return (svd.U * w * svd.VT).ConjugateTranspose();
         }
 
         /// <summary>


### PR DESCRIPTION
Moore-Penrose Pseudo-Inverse currently gives wrong results for complex matrices. This PR adds tests for Pseudo-Inverses and fixes the implementation for complex matrices.

The tests fails for DiagonalMatrix because there seems to be a bug in the multiplication of non square diagonal matrices with sparse matrices. Unfortunately I am not able to fix this bug.