### PR TITLE
fix the error on index of observations' weights

### DIFF
--- a/src/Numerics/Optimization/ObjectiveFunctions/NonlinearObjectiveFunction.cs
+++ b/src/Numerics/Optimization/ObjectiveFunctions/NonlinearObjectiveFunction.cs
@@ -333,7 +333,7 @@ namespace MathNet.Numerics.Optimization.ObjectiveFunctions
                     {
                         jacobianValue[i, j] = (Weights == null)
                             ? jacobianValue[i, j]
-                            : jacobianValue[i, j] * L[j];
+                            : jacobianValue[i, j] * L[i];
                     }
                 }
             }


### PR DESCRIPTION
"L" is the weights for the observations.
"i" in EvaluateJacobian() method is the NumberOfObservations. so the "L"'s index should be "i".