### PR TITLE
Allow empty Vector and Matrix

### DIFF
--- a/src/Numerics.Tests/LinearAlgebraTests/Complex/DenseMatrixTests.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Complex/DenseMatrixTests.cs
@@ -166,8 +166,8 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Complex
         /// Identity with wrong order throws <c>ArgumentOutOfRangeException</c>.
         /// </summary>
         /// <param name="order">The size of the square matrix</param>
-        [TestCase(0)]
         [TestCase(-1)]
+        [TestCase(-2)]
         public void IdentityWithWrongOrderThrowsArgumentOutOfRangeException(int order)
         {
             Assert.That(() => DenseMatrix.CreateIdentity(order), Throws.TypeOf<ArgumentOutOfRangeException>());

--- a/src/Numerics.Tests/LinearAlgebraTests/Complex/DiagonalMatrixTests.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Complex/DiagonalMatrixTests.cs
@@ -177,8 +177,8 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Complex
         /// Identity with wrong order throws <c>ArgumentOutOfRangeException</c>.
         /// </summary>
         /// <param name="order">The size of the square matrix</param>
-        [TestCase(0)]
         [TestCase(-1)]
+        [TestCase(-2)]
         public void IdentityWithWrongOrderThrowsArgumentOutOfRangeException(int order)
         {
             Assert.That(() => DiagonalMatrix.CreateIdentity(order), Throws.TypeOf<ArgumentOutOfRangeException>());

--- a/src/Numerics.Tests/LinearAlgebraTests/Complex/MatrixTests.Arithmetic.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Complex/MatrixTests.Arithmetic.cs
@@ -1047,7 +1047,7 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Complex
         /// Create random matrix with non-positive number of rows throw <c>ArgumentException</c>.
         /// </summary>
         /// <param name="numberOfRows">Number of rows.</param>
-        [TestCase(0)]
+        [TestCase(-1)]
         [TestCase(-2)]
         public void RandomWithNonPositiveNumberOfRowsThrowsArgumentException(int numberOfRows)
         {

--- a/src/Numerics.Tests/LinearAlgebraTests/Complex/SparseMatrixTests.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Complex/SparseMatrixTests.cs
@@ -151,8 +151,8 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Complex
         /// Identity with wrong order throws <c>ArgumentOutOfRangeException</c>.
         /// </summary>
         /// <param name="order">The size of the square matrix</param>
-        [TestCase(0)]
         [TestCase(-1)]
+        [TestCase(-2)]
         public void IdentityWithWrongOrderThrowsArgumentOutOfRangeException(int order)
         {
             Assert.That(() => SparseMatrix.CreateIdentity(order), Throws.TypeOf<ArgumentOutOfRangeException>());

--- a/src/Numerics.Tests/LinearAlgebraTests/Complex/VectorTests.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Complex/VectorTests.cs
@@ -63,7 +63,7 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Complex
             Assert.AreEqual(vector.Count, clone.Count);
             CollectionAssert.AreEqual(vector, clone);
         }
-        
+
         /// <summary>
         /// Can clone a vector using <c>IClonable</c> interface method.
         /// </summary>
@@ -198,7 +198,6 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Complex
         public void SizeIsNotPositiveThrowsArgumentOutOfRangeException()
         {
             Assert.That(() => CreateVector(-1), Throws.TypeOf<ArgumentOutOfRangeException>());
-            Assert.That(() => CreateVector(0), Throws.TypeOf<ArgumentOutOfRangeException>());
         }
 
         /// <summary>

--- a/src/Numerics.Tests/LinearAlgebraTests/Complex32/DenseMatrixTests.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Complex32/DenseMatrixTests.cs
@@ -166,8 +166,8 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Complex32
         /// Identity with wrong order throws <c>ArgumentOutOfRangeException</c>.
         /// </summary>
         /// <param name="order">The size of the square matrix</param>
-        [TestCase(0)]
         [TestCase(-1)]
+        [TestCase(-2)]
         public void IdentityWithWrongOrderThrowsArgumentOutOfRangeException(int order)
         {
             Assert.That(() => DenseMatrix.CreateIdentity(order), Throws.TypeOf<ArgumentOutOfRangeException>());

--- a/src/Numerics.Tests/LinearAlgebraTests/Complex32/DiagonalMatrixTests.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Complex32/DiagonalMatrixTests.cs
@@ -177,8 +177,8 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Complex32
         /// Identity with wrong order throws <c>ArgumentOutOfRangeException</c>.
         /// </summary>
         /// <param name="order">The size of the square matrix</param>
-        [TestCase(0)]
         [TestCase(-1)]
+        [TestCase(-2)]
         public void IdentityWithWrongOrderThrowsArgumentOutOfRangeException(int order)
         {
             Assert.That(() => DiagonalMatrix.CreateIdentity(order), Throws.TypeOf<ArgumentOutOfRangeException>());

--- a/src/Numerics.Tests/LinearAlgebraTests/Complex32/MatrixTests.Arithmetic.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Complex32/MatrixTests.Arithmetic.cs
@@ -1044,7 +1044,7 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Complex32
         /// Create random matrix with non-positive number of rows throw <c>ArgumentException</c>.
         /// </summary>
         /// <param name="numberOfRows">Number of rows.</param>
-        [TestCase(0)]
+        [TestCase(-1)]
         [TestCase(-2)]
         public void RandomWithNonPositiveNumberOfRowsThrowsArgumentException(int numberOfRows)
         {

--- a/src/Numerics.Tests/LinearAlgebraTests/Complex32/SparseMatrixTests.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Complex32/SparseMatrixTests.cs
@@ -151,8 +151,8 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Complex32
         /// Identity with wrong order throws <c>ArgumentOutOfRangeException</c>.
         /// </summary>
         /// <param name="order">The size of the square matrix</param>
-        [TestCase(0)]
         [TestCase(-1)]
+        [TestCase(-2)]
         public void IdentityWithWrongOrderThrowsArgumentOutOfRangeException(int order)
         {
             Assert.That(() => SparseMatrix.CreateIdentity(order), Throws.TypeOf<ArgumentOutOfRangeException>());

--- a/src/Numerics.Tests/LinearAlgebraTests/Complex32/VectorTests.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Complex32/VectorTests.cs
@@ -63,7 +63,7 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Complex32
             Assert.AreEqual(vector.Count, clone.Count);
             CollectionAssert.AreEqual(vector, clone);
         }
-        
+
         /// <summary>
         /// Can clone a vector using <c>IClonable</c> interface method.
         /// </summary>
@@ -198,7 +198,6 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Complex32
         public void SizeIsNotPositiveThrowsArgumentOutOfRangeException()
         {
             Assert.That(() => CreateVector(-1), Throws.TypeOf<ArgumentOutOfRangeException>());
-            Assert.That(() => CreateVector(0), Throws.TypeOf<ArgumentOutOfRangeException>());
         }
 
         /// <summary>

--- a/src/Numerics.Tests/LinearAlgebraTests/Double/DenseMatrixTests.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Double/DenseMatrixTests.cs
@@ -167,8 +167,8 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Double
         /// Identity with wrong order throws <c>ArgumentOutOfRangeException</c>.
         /// </summary>
         /// <param name="order">The size of the square matrix</param>
-        [TestCase(0)]
         [TestCase(-1)]
+        [TestCase(-2)]
         public void IdentityWithWrongOrderThrowsArgumentOutOfRangeException(int order)
         {
             Assert.That(() => Matrix<double>.Build.DenseIdentity(order), Throws.TypeOf<ArgumentOutOfRangeException>());

--- a/src/Numerics.Tests/LinearAlgebraTests/Double/DiagonalMatrixTests.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Double/DiagonalMatrixTests.cs
@@ -176,8 +176,8 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Double
         /// Identity with wrong order throws <c>ArgumentOutOfRangeException</c>.
         /// </summary>
         /// <param name="order">The size of the square matrix</param>
-        [TestCase(0)]
         [TestCase(-1)]
+        [TestCase(-2)]
         public void IdentityWithWrongOrderThrowsArgumentOutOfRangeException(int order)
         {
             Assert.That(() => Matrix<double>.Build.DiagonalIdentity(order), Throws.TypeOf<ArgumentOutOfRangeException>());

--- a/src/Numerics.Tests/LinearAlgebraTests/Double/MatrixTests.Arithmetic.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Double/MatrixTests.Arithmetic.cs
@@ -1037,7 +1037,7 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Double
         /// Create random matrix with non-positive number of rows throw <c>ArgumentException</c>.
         /// </summary>
         /// <param name="numberOfRows">Number of rows.</param>
-        [TestCase(0)]
+        [TestCase(-1)]
         [TestCase(-2)]
         public void RandomWithNonPositiveNumberOfRowsThrowsArgumentException(int numberOfRows)
         {

--- a/src/Numerics.Tests/LinearAlgebraTests/Double/SparseMatrixTests.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Double/SparseMatrixTests.cs
@@ -150,8 +150,8 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Double
         /// Identity with wrong order throws <c>ArgumentOutOfRangeException</c>.
         /// </summary>
         /// <param name="order">The size of the square matrix</param>
-        [TestCase(0)]
         [TestCase(-1)]
+        [TestCase(-2)]
         public void IdentityWithWrongOrderThrowsArgumentOutOfRangeException(int order)
         {
             Assert.That(() => Matrix<double>.Build.SparseIdentity(order), Throws.TypeOf<ArgumentOutOfRangeException>());

--- a/src/Numerics.Tests/LinearAlgebraTests/Double/VectorTests.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Double/VectorTests.cs
@@ -59,7 +59,7 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Double
             Assert.AreEqual(vector.Count, clone.Count);
             CollectionAssert.AreEqual(vector, clone);
         }
-        
+
         /// <summary>
         /// Can clone a vector using <c>IClonable</c> interface method.
         /// </summary>
@@ -194,7 +194,6 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Double
         public void SizeIsNotPositiveThrowsArgumentOutOfRangeException()
         {
             Assert.That(() => CreateVector(-1), Throws.TypeOf<ArgumentOutOfRangeException>());
-            Assert.That(() => CreateVector(0), Throws.TypeOf<ArgumentOutOfRangeException>());
         }
 
         /// <summary>

--- a/src/Numerics.Tests/LinearAlgebraTests/MatrixStructureTheory.Access.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/MatrixStructureTheory.Access.cs
@@ -126,7 +126,6 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests
             Assert.That(() => matrix.Row(-1, 0, 2), Throws.InstanceOf<ArgumentOutOfRangeException>());
             Assert.That(() => matrix.Row(matrix.RowCount, 0, 1), Throws.InstanceOf<ArgumentOutOfRangeException>());
             Assert.That(() => matrix.Row(0, -1, 1), Throws.InstanceOf<ArgumentOutOfRangeException>());
-            Assert.That(() => matrix.Row(0, 1, 0), Throws.InstanceOf<ArgumentOutOfRangeException>());
             Assert.That(() => matrix.Row(0, 0, matrix.ColumnCount + 1), Throws.InstanceOf<ArgumentOutOfRangeException>());
         }
 
@@ -226,7 +225,6 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests
             Assert.That(() => matrix.Column(-1, 0, 2), Throws.InstanceOf<ArgumentOutOfRangeException>());
             Assert.That(() => matrix.Column(matrix.ColumnCount, 0, 1), Throws.InstanceOf<ArgumentOutOfRangeException>());
             Assert.That(() => matrix.Column(0, -1, 1), Throws.InstanceOf<ArgumentOutOfRangeException>());
-            Assert.That(() => matrix.Column(0, 1, 0), Throws.InstanceOf<ArgumentOutOfRangeException>());
             Assert.That(() => matrix.Column(0, 0, matrix.RowCount + 1), Throws.InstanceOf<ArgumentOutOfRangeException>());
         }
 
@@ -667,10 +665,8 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests
             // Invalid
             Assert.That(() => matrix.SubMatrix(-1, 1, 0, 1), Throws.InstanceOf<ArgumentOutOfRangeException>());
             Assert.That(() => matrix.SubMatrix(matrix.RowCount, 1, 0, 1), Throws.InstanceOf<ArgumentOutOfRangeException>());
-            Assert.That(() => matrix.SubMatrix(0, 0, 0, 1), Throws.InstanceOf<ArgumentOutOfRangeException>());
             Assert.That(() => matrix.SubMatrix(0, 1, -1, 1), Throws.InstanceOf<ArgumentOutOfRangeException>());
             Assert.That(() => matrix.SubMatrix(0, 1, matrix.ColumnCount, 1), Throws.InstanceOf<ArgumentOutOfRangeException>());
-            Assert.That(() => matrix.SubMatrix(0, 1, 0, 0), Throws.InstanceOf<ArgumentOutOfRangeException>());
         }
 
         [Theory]

--- a/src/Numerics.Tests/LinearAlgebraTests/MatrixStructureTheory.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/MatrixStructureTheory.cs
@@ -141,7 +141,7 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests
             Assert.That(clone.RowCount, Is.EqualTo(matrix.RowCount));
             Assert.That(clone.ColumnCount, Is.EqualTo(matrix.ColumnCount));
         }
-        
+
         [Theory]
         public void CanCloneUsingICloneable(TestMatrix testMatrix)
         {
@@ -415,8 +415,8 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests
             Assert.That(empty, Is.EqualTo(Matrix<T>.Build.Dense(5, 6)));
             Assert.That(empty.Storage.IsDense, Is.EqualTo(matrix.Storage.IsDense));
 
-            Assert.That(() => Matrix<T>.Build.SameAs(matrix, 0, 2), Throws.InstanceOf<ArgumentOutOfRangeException>());
-            Assert.That(() => Matrix<T>.Build.SameAs(matrix, 2, 0), Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(() => Matrix<T>.Build.SameAs(matrix, -1, 2), Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(() => Matrix<T>.Build.SameAs(matrix, 2, -1), Throws.InstanceOf<ArgumentOutOfRangeException>());
             Assert.That(() => Matrix<T>.Build.SameAs(matrix, -1, -1), Throws.InstanceOf<ArgumentOutOfRangeException>());
         }
 

--- a/src/Numerics.Tests/LinearAlgebraTests/MatrixTests.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/MatrixTests.cs
@@ -1,0 +1,77 @@
+﻿// <copyright file="VectorStorageCombinatorsTests.cs" company="Math.NET">
+// Math.NET Numerics, part of the Math.NET Project
+// http://numerics.mathdotnet.com
+// http://github.com/mathnet/mathnet-numerics
+//
+// Copyright (c) 2009-2016 Math.NET
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+
+using System;
+using MathNet.Numerics.LinearAlgebra;
+using MathNet.Numerics.LinearAlgebra.Storage;
+using NUnit.Framework;
+
+namespace MathNet.Numerics.UnitTests.LinearAlgebraTests
+{
+    [TestFixture, Category("LA")]
+    public class MatrixTests
+    {
+        [Test]
+        public void DenseMatrixBuilderMethos_ZeroLength_DoNotThrowException()
+        {
+            Assert.DoesNotThrow(() => Matrix<double>.Build.Dense(0, 0));
+            Assert.DoesNotThrow(() => Matrix<double>.Build.Dense(0, 0, 42));
+            Assert.DoesNotThrow(() => Matrix<double>.Build.Dense(0, 0, Array.Empty<double>()));
+            Assert.DoesNotThrow(() => Matrix<double>.Build.Dense(0, 0, (row, column) => 42));
+        }
+
+        [Test]
+        public void SparseMatrixBuilderMethos_ZeroLength_DoNotThrowException()
+        {
+            Assert.DoesNotThrow(() => Matrix<double>.Build.Sparse(0, 0));
+            Assert.DoesNotThrow(() => Matrix<double>.Build.Sparse(0, 0, 42));
+            Assert.DoesNotThrow(() => Matrix<double>.Build.Sparse(0, 0, (row, column) => 42));
+        }
+
+        [Test]
+        public void DenseColumnMajorMatrixStorageBuilderMethods_ZeroLength_DoNotThrowException()
+        {
+            Assert.DoesNotThrow(() => new DenseColumnMajorMatrixStorage<double>(0, 0));
+            Assert.DoesNotThrow(() => new DenseColumnMajorMatrixStorage<double>(0, 0, Array.Empty<double>()));
+        }
+
+        [Test]
+        public void DiagonalMatrixStorageBuilderMethods_ZeroLength_DoNotThrowException()
+        {
+            Assert.DoesNotThrow(() => new DiagonalMatrixStorage<double>(0, 0));
+            Assert.DoesNotThrow(() => new DiagonalMatrixStorage<double>(0, 0, Array.Empty<double>()));
+        }
+
+        [Test]
+        public void SparseCompressedRowMatrixStorageBuilderMethods_ZeroLength_DoNotThrowException()
+        {
+            Assert.DoesNotThrow(() => new SparseCompressedRowMatrixStorage<double>(0, 0));
+        }
+    }
+}

--- a/src/Numerics.Tests/LinearAlgebraTests/Single/DenseMatrixTests.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Single/DenseMatrixTests.cs
@@ -164,8 +164,8 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Single
         /// Identity with wrong order throws <c>ArgumentOutOfRangeException</c>.
         /// </summary>
         /// <param name="order">The size of the square matrix</param>
-        [TestCase(0)]
         [TestCase(-1)]
+        [TestCase(-2)]
         public void IdentityWithWrongOrderThrowsArgumentOutOfRangeException(int order)
         {
             Assert.That(() => DenseMatrix.CreateIdentity(order), Throws.TypeOf<ArgumentOutOfRangeException>());

--- a/src/Numerics.Tests/LinearAlgebraTests/Single/DiagonalMatrixTests.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Single/DiagonalMatrixTests.cs
@@ -174,8 +174,8 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Single
         /// Identity with wrong order throws <c>ArgumentOutOfRangeException</c>.
         /// </summary>
         /// <param name="order">The size of the square matrix</param>
-        [TestCase(0)]
         [TestCase(-1)]
+        [TestCase(-2)]
         public void IdentityWithWrongOrderThrowsArgumentOutOfRangeException(int order)
         {
             Assert.That(() => DiagonalMatrix.CreateIdentity(order), Throws.TypeOf<ArgumentOutOfRangeException>());

--- a/src/Numerics.Tests/LinearAlgebraTests/Single/MatrixTests.Arithmetic.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Single/MatrixTests.Arithmetic.cs
@@ -1032,7 +1032,7 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Single
         /// Create random matrix with non-positive number of rows throw <c>ArgumentException</c>.
         /// </summary>
         /// <param name="numberOfRows">Number of rows.</param>
-        [TestCase(0)]
+        [TestCase(-1)]
         [TestCase(-2)]
         public void RandomWithNonPositiveNumberOfRowsThrowsArgumentException(int numberOfRows)
         {

--- a/src/Numerics.Tests/LinearAlgebraTests/Single/SparseMatrixTests.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Single/SparseMatrixTests.cs
@@ -149,8 +149,8 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Single
         /// Identity with wrong order throws <c>ArgumentOutOfRangeException</c>.
         /// </summary>
         /// <param name="order">The size of the square matrix</param>
-        [TestCase(0)]
         [TestCase(-1)]
+        [TestCase(-2)]
         public void IdentityWithWrongOrderThrowsArgumentOutOfRangeException(int order)
         {
             Assert.That(() => SparseMatrix.CreateIdentity(order), Throws.TypeOf<ArgumentOutOfRangeException>());

--- a/src/Numerics.Tests/LinearAlgebraTests/Single/VectorTests.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Single/VectorTests.cs
@@ -60,7 +60,7 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Single
             Assert.AreEqual(vector.Count, clone.Count);
             CollectionAssert.AreEqual(vector, clone);
         }
-        
+
         /// <summary>
         /// Can clone a vector using <c>IClonable</c> interface method.
         /// </summary>
@@ -195,7 +195,6 @@ namespace MathNet.Numerics.UnitTests.LinearAlgebraTests.Single
         public void SizeIsNotPositiveThrowsArgumentOutOfRangeException()
         {
             Assert.That(() => CreateVector(-1), Throws.TypeOf<ArgumentOutOfRangeException>());
-            Assert.That(() => CreateVector(0), Throws.TypeOf<ArgumentOutOfRangeException>());
         }
 
         /// <summary>

--- a/src/Numerics.Tests/LinearAlgebraTests/VectorTests.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/VectorTests.cs
@@ -1,0 +1,107 @@
+﻿// <copyright file="VectorStorageCombinatorsTests.cs" company="Math.NET">
+// Math.NET Numerics, part of the Math.NET Project
+// http://numerics.mathdotnet.com
+// http://github.com/mathnet/mathnet-numerics
+//
+// Copyright (c) 2009-2016 Math.NET
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+
+using System;
+using MathNet.Numerics.LinearAlgebra;
+using MathNet.Numerics.LinearAlgebra.Storage;
+using MathNet.Numerics.Properties;
+using NUnit.Framework;
+
+namespace MathNet.Numerics.UnitTests.LinearAlgebraTests
+{
+    [TestFixture, Category("LA")]
+    public class VectorTests
+    {
+        [Test]
+        public void DenseVectorBuilderMethod_ZeroLength_DoNotThrowException()
+        {
+            Assert.DoesNotThrow(() => Vector<double>.Build.Dense(0));
+            Assert.DoesNotThrow(() => Vector<double>.Build.Dense(0, 42));
+            Assert.DoesNotThrow(() => Vector<double>.Build.Dense(0, index => 42));
+            Assert.DoesNotThrow(() => Vector<double>.Build.Dense(Array.Empty<double>()));
+        }
+
+        [Test]
+        public void SparseVectorBuilderMethods_ZeroLength_DoNotThrowException()
+        {
+            Assert.DoesNotThrow(() => Vector<double>.Build.Sparse(0));
+            Assert.DoesNotThrow(() => Vector<double>.Build.Sparse(0, 42));
+            Assert.DoesNotThrow(() => Vector<double>.Build.Sparse(0, index => 42));
+        }
+
+        [Test]
+        public void DenseVectorStorageBuilderMethods_ZeroLength_DoNotThrowException()
+        {
+            Assert.DoesNotThrow(() => new DenseVectorStorage<double>(0));
+            Assert.DoesNotThrow(() => new DenseVectorStorage<double>(0, Array.Empty<double>()));
+            Assert.DoesNotThrow(() => DenseVectorStorage<double>.OfValue(0, 42));
+            Assert.DoesNotThrow(() => DenseVectorStorage<double>.OfInit(0, index => 42));
+        }
+
+        [Test]
+        public void SparseVectorStorageBuilderMethods_ZeroLength_DoNotThrowException()
+        {
+            Assert.DoesNotThrow(() => new SparseVectorStorage<double>(0));
+            Assert.DoesNotThrow(() => SparseVectorStorage<double>.OfValue(0, 42));
+            Assert.DoesNotThrow(() => SparseVectorStorage<double>.OfInit(0, index => 42));
+        }
+
+        [Test]
+        public void DenseVectorStorageOfInit_NegativeLength_ThrowsArgumentException()
+        {
+            Assert.That(() => DenseVectorStorage<double>.OfInit(-1, index => 42),
+                Throws.TypeOf<ArgumentOutOfRangeException>()
+                .With.Message.Contains(Resources.ArgumentNotNegative));
+        }
+
+        [Test]
+        public void DenseVectorStorageOfValue_NegativeLength_ThrowsArgumentException()
+        {
+            Assert.That(() => DenseVectorStorage<double>.OfValue(-1, 42),
+                Throws.TypeOf<ArgumentOutOfRangeException>()
+                .With.Message.Contains(Resources.ArgumentNotNegative));
+        }
+
+        [Test]
+        public void SparseVectorStorageOfInit_NegativeLength_ThrowsArgumentException()
+        {
+            Assert.That(() => SparseVectorStorage<double>.OfInit(-1, index => 42),
+                Throws.TypeOf<ArgumentOutOfRangeException>()
+                .With.Message.Contains(Resources.ArgumentNotNegative));
+        }
+
+        [Test]
+        public void SparseVectorStorageOfValue_NegativeLength_ThrowsArgumentException()
+        {
+            Assert.That(() => SparseVectorStorage<double>.OfValue(-1, 42),
+                Throws.TypeOf<ArgumentOutOfRangeException>()
+                .With.Message.Contains(Resources.ArgumentNotNegative));
+        }
+    }
+}

--- a/src/Numerics/LinearAlgebra/Storage/DenseVectorStorage.cs
+++ b/src/Numerics/LinearAlgebra/Storage/DenseVectorStorage.cs
@@ -115,9 +115,9 @@ namespace MathNet.Numerics.LinearAlgebra.Storage
 
         public static DenseVectorStorage<T> OfValue(int length, T value)
         {
-            if (length < 1)
+            if (length < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(length), string.Format(Resources.ArgumentLessThanOne, length));
+                throw new ArgumentOutOfRangeException(nameof(length), Resources.ArgumentNotNegative);
             }
 
             var data = new T[length];
@@ -133,9 +133,9 @@ namespace MathNet.Numerics.LinearAlgebra.Storage
 
         public static DenseVectorStorage<T> OfInit(int length, Func<int, T> init)
         {
-            if (length < 1)
+            if (length < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(length), string.Format(Resources.ArgumentLessThanOne, length));
+                throw new ArgumentOutOfRangeException(nameof(length), Resources.ArgumentNotNegative);
             }
 
             var data = new T[length];

--- a/src/Numerics/LinearAlgebra/Storage/MatrixStorage.cs
+++ b/src/Numerics/LinearAlgebra/Storage/MatrixStorage.cs
@@ -51,12 +51,12 @@ namespace MathNet.Numerics.LinearAlgebra.Storage
 
         protected MatrixStorage(int rowCount, int columnCount)
         {
-            if (rowCount <= 0)
+            if (rowCount < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(rowCount), Resources.MatrixRowsMustBePositive);
             }
 
-            if (columnCount <= 0)
+            if (columnCount < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(columnCount), Resources.MatrixColumnsMustBePositive);
             }

--- a/src/Numerics/LinearAlgebra/Storage/SparseVectorStorage.cs
+++ b/src/Numerics/LinearAlgebra/Storage/SparseVectorStorage.cs
@@ -315,9 +315,9 @@ namespace MathNet.Numerics.LinearAlgebra.Storage
                 return new SparseVectorStorage<T>(length);
             }
 
-            if (length < 1)
+            if (length < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(length), string.Format(Resources.ArgumentLessThanOne, length));
+                throw new ArgumentOutOfRangeException(nameof(length), Resources.ArgumentNotNegative);
             }
 
             var indices = new int[length];
@@ -338,9 +338,9 @@ namespace MathNet.Numerics.LinearAlgebra.Storage
 
         public static SparseVectorStorage<T> OfInit(int length, Func<int, T> init)
         {
-            if (length < 1)
+            if (length < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(length), string.Format(Resources.ArgumentLessThanOne, length));
+                throw new ArgumentOutOfRangeException(nameof(length), Resources.ArgumentNotNegative);
             }
 
             var indices = new List<int>();

--- a/src/Numerics/LinearAlgebra/Storage/VectorStorage.cs
+++ b/src/Numerics/LinearAlgebra/Storage/VectorStorage.cs
@@ -48,9 +48,9 @@ namespace MathNet.Numerics.LinearAlgebra.Storage
 
         protected VectorStorage(int length)
         {
-            if (length <= 0)
+            if (length < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(length), Resources.ArgumentMustBePositive);
+                throw new ArgumentOutOfRangeException(nameof(length), Resources.ArgumentNotNegative);
             }
 
             Length = length;


### PR DESCRIPTION
Fix #134 

This is an attempt at allowing empty (zero-length) `Vector` and `Matrix`. I am relying on the existing tests to find any issue with what I have done as I am not enough of an expert to see if there are any unwanted consequences.