### PR TITLE
Fix RayleightTests.ValidateMaximum test to use testcase parameter

### DIFF
--- a/src/Numerics.Tests/DistributionTests/Continuous/RayleighTests.cs
+++ b/src/Numerics.Tests/DistributionTests/Continuous/RayleighTests.cs
@@ -200,7 +200,7 @@ namespace MathNet.Numerics.UnitTests.DistributionTests.Continuous
         [TestCase(Double.PositiveInfinity)]
         public void ValidateMaximum(double scale)
         {
-            var n = new Rayleigh(1.0);
+            var n = new Rayleigh(scale);
             Assert.AreEqual(Double.PositiveInfinity, n.Maximum);
         }
 


### PR DESCRIPTION
Fix `RayleightTests.ValidateMaximum` test to use the scale parameter instead of the hardcoded value.

Fix #708