### PR TITLE
Brent Minimizer

### DIFF
--- a/src/Numerics.Tests/OptimizationTests/BrentMinimizerTests.cs
+++ b/src/Numerics.Tests/OptimizationTests/BrentMinimizerTests.cs
@@ -1,0 +1,60 @@
+﻿// <copyright file="BrentMinimizerTests.cs" company="Math.NET">
+// Math.NET Numerics, part of the Math.NET Project
+// http://numerics.mathdotnet.com
+// http://github.com/mathnet/mathnet-numerics
+//
+// Copyright (c) 2009-2017 Math.NET
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+
+using System;
+using MathNet.Numerics.Optimization;
+using NUnit.Framework;
+
+namespace MathNet.Numerics.UnitTests.OptimizationTests
+{
+    [TestFixture]
+    public class BrentMinimizerTests
+    {
+        [Test]
+        public void Test_Works()
+        {
+            var f1 = new Func<double, double>(x => (x - 3) * (x - 3));
+            var obj = ObjectiveFunction.ScalarValue(f1);
+            var r1 = BrentMinimizer.Minimum(obj, -100, 100);
+
+            Assert.That(Math.Abs(r1.MinimizingPoint - 3.0), Is.LessThan(1e-4));
+        }
+
+        [Test]
+        public void Test_ExpansionWorks()
+        {
+            var algorithm = new BrentMinimizer(1e-5, 1000);
+            var f1 = new Func<double, double>(x => (x - 3) * (x - 3));
+            var obj = ObjectiveFunction.ScalarValue(f1);
+            var r1 = algorithm.FindMinimum(obj, -5, 5);
+
+            Assert.That(Math.Abs(r1.MinimizingPoint - 3.0), Is.LessThan(1e-4));
+        }
+    }
+}

--- a/src/Numerics/Optimization/BrentMinimizer.cs
+++ b/src/Numerics/Optimization/BrentMinimizer.cs
@@ -1,0 +1,69 @@
+﻿// <copyright file="GoldenSectionMinimizer.cs" company="Math.NET">
+// Math.NET Numerics, part of the Math.NET Project
+// http://numerics.mathdotnet.com
+// http://github.com/mathnet/mathnet-numerics
+//
+// Copyright (c) 2009-2017 Math.NET
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+
+using System;
+
+namespace MathNet.Numerics.Optimization
+{
+    public class BrentMinimizer
+    {
+        public double XTolerance { get; set; }
+        public int MaximumIterations { get; set; }
+        public int MaximumExpansionSteps { get; set; }
+        public double LowerExpansionFactor { get; set; }
+        public double UpperExpansionFactor { get; set; }
+
+        public BrentMinimizer(double xTolerance = 1e-5, int maxIterations = 1000, int maxExpansionSteps = 10, double lowerExpansionFactor = 2.0, double upperExpansionFactor = 2.0)
+        {
+            XTolerance = xTolerance;
+            MaximumIterations = maxIterations;
+            MaximumExpansionSteps = maxExpansionSteps;
+            LowerExpansionFactor = lowerExpansionFactor;
+            UpperExpansionFactor = upperExpansionFactor;
+        }
+
+        public ScalarMinimizationResult FindMinimum(IScalarObjectiveFunction objective, double lowerBound, double upperBound)
+        {
+            return Minimum(objective, lowerBound, upperBound, XTolerance, MaximumIterations, MaximumExpansionSteps, LowerExpansionFactor, UpperExpansionFactor);
+        }
+
+        public static ScalarMinimizationResult Minimum(IScalarObjectiveFunction objective, double lowerBound, double upperBound, double xTolerance = 1e-5, int maxIterations = 1000, int maxExpansionSteps = 10, double lowerExpansionFactor = 2.0, double upperExpansionFactor = 2.0)
+        {
+            return null;
+        }
+
+        static void ValueChecker(double value, double point)
+        {
+            if (Double.IsNaN(value) || Double.IsInfinity(value))
+            {
+                throw new Exception("Objective function returned non-finite value.");
+            }
+        }
+    }
+}

--- a/src/Numerics/Optimization/BrentMinimizer.cs
+++ b/src/Numerics/Optimization/BrentMinimizer.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="GoldenSectionMinimizer.cs" company="Math.NET">
+﻿// <copyright file="BrentMinimizer.cs" company="Math.NET">
 // Math.NET Numerics, part of the Math.NET Project
 // http://numerics.mathdotnet.com
 // http://github.com/mathnet/mathnet-numerics


### PR DESCRIPTION
Hi all,

I recently was looking for a Brent minimizer when porting some python code to C# and I was hoping to find it here. `FindMinimum.OfScalarFunctionConstrained()` was pretty close, but given it is Golden Section under the covers, there were discrepancies with some inputs. I ended up porting the version from scipy [_minimize_scalar_bounded()](https://github.com/scipy/scipy/blob/v1.5.2/scipy/optimize/optimize.py#L1883).

I'd love to give back and contribute this port (and perhaps expand on it a little bit). Is this something of interest to the project? I've started a PR with a simple mock up of the rough API and tests I was thinking about (copied from GoldenSectionMinimizer).

Also, I noticed that there was quite a history with optimizers (#489, #173), so I thought I'd check first. I see that a BrentMinimizer class was considered in the past [optimization-1](https://github.com/mathnet/mathnet-numerics/blob/optimization-1/src/Numerics/Optimization/BrentMinimizer.cs). But it doesn't look like this has been updated in quite some time. Any insight here would be great.