### PR TITLE
Fix for #730 - a few operations broken on zero polynomials

### DIFF
--- a/src/Numerics.Tests/PolynomialTests.cs
+++ b/src/Numerics.Tests/PolynomialTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="FitTests.cs" company="Math.NET">
+﻿// <copyright file="PolynomialTests.cs" company="Math.NET">
 // Math.NET Numerics, part of the Math.NET Project
 // http://numerics.mathdotnet.com
 // http://github.com/mathnet/mathnet-numerics

--- a/src/Numerics/Polynomial.cs
+++ b/src/Numerics/Polynomial.cs
@@ -144,16 +144,36 @@ namespace MathNet.Numerics
         /// </summary>
         /// <param name="z">The location where to evaluate the polynomial at.</param>
         /// <param name="coefficients">The coefficients of the polynomial, coefficient for power k at index k.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="coefficients"/> is a null reference.
+        /// </exception>
         public static double Evaluate(double z, params double[] coefficients)
         {
-            double sum = coefficients[coefficients.Length - 1];
-            for (int i = coefficients.Length - 2; i >= 0; --i)
+
+            // 2020-10-07 jbialogrodzki #730 Since this is public API we should probably
+            // handle null arguments? It doesn't seem to have been done consistently in this class though.
+            if (coefficients == null)
+            {
+                throw new ArgumentNullException(nameof(coefficients));
+            }
+
+            // 2020-10-07 jbialogrodzki #730 Zero polynomials need explicit handling.
+            // Without this check, we attempted to peek coefficients at negative indices!
+            int n = coefficients.Length;
+            if (n == 0)
+            {
+                return 0;
+            }
+
+            double sum = coefficients[n - 1];
+            for (int i = n - 2; i >= 0; --i)
             {
                 sum *= z;
                 sum += coefficients[i];
             }
 
             return sum;
+
         }
 
         /// <summary>
@@ -163,16 +183,36 @@ namespace MathNet.Numerics
         /// </summary>
         /// <param name="z">The location where to evaluate the polynomial at.</param>
         /// <param name="coefficients">The coefficients of the polynomial, coefficient for power k at index k.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="coefficients"/> is a null reference.
+        /// </exception>
         public static Complex Evaluate(Complex z, params double[] coefficients)
         {
-            Complex sum = coefficients[coefficients.Length - 1];
-            for (int i = coefficients.Length - 2; i >= 0; --i)
+
+            // 2020-10-07 jbialogrodzki #730 Since this is a public API we should probably
+            // handle null arguments? It doesn't seem to have been done consistently in this class though.
+            if (coefficients == null)
+            {
+                throw new ArgumentNullException(nameof(coefficients));
+            }
+
+            // 2020-10-07 jbialogrodzki #730 Zero polynomials need explicit handling.
+            // Without this check, we attempted to peek coefficients at negative indices!
+            int n = coefficients.Length;
+            if (n == 0)
+            {
+                return 0;
+            }
+
+            Complex sum = coefficients[n - 1];
+            for (int i = n - 2; i >= 0; --i)
             {
                 sum *= z;
                 sum += coefficients[i];
             }
 
             return sum;
+
         }
 
         /// <summary>
@@ -182,16 +222,36 @@ namespace MathNet.Numerics
         /// </summary>
         /// <param name="z">The location where to evaluate the polynomial at.</param>
         /// <param name="coefficients">The coefficients of the polynomial, coefficient for power k at index k.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="coefficients"/> is a null reference.
+        /// </exception>
         public static Complex Evaluate(Complex z, params Complex[] coefficients)
         {
-            Complex sum = coefficients[coefficients.Length - 1];
-            for (int i = coefficients.Length - 2; i >= 0; --i)
+
+            // 2020-10-07 jbialogrodzki #730 Since this is a public API we should probably
+            // handle null arguments? It doesn't seem to have been done consistently in this class though.
+            if (coefficients == null)
+            {
+                throw new ArgumentNullException(nameof(coefficients));
+            }
+
+            // 2020-10-07 jbialogrodzki #730 Zero polynomials need explicit handling.
+            // Without this check, we attempted to peek coefficients at negative indices!
+            int n = coefficients.Length;
+            if (n == 0)
+            {
+                return 0;
+            }
+
+            Complex sum = coefficients[n - 1];
+            for (int i = n - 2; i >= 0; --i)
             {
                 sum *= z;
                 sum += coefficients[i];
             }
 
             return sum;
+
         }
 
         /// <summary>
@@ -480,10 +540,34 @@ namespace MathNet.Numerics
         /// <param name="a">Left polynomial</param>
         /// <param name="b">Right polynomial</param>
         /// <returns>Resulting Polynomial</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="a"/> or <paramref name="b"/> is a null reference.
+        /// </exception>
         public static Polynomial Multiply(Polynomial a, Polynomial b)
         {
+
+            // 2020-10-07 jbialogrodzki #730 Since this is a public API we should probably
+            // handle null arguments? It doesn't seem to have been done consistently in this class though.
+            if (a == null)
+            {
+                throw new ArgumentNullException(nameof(a));
+            }
+
+            if (b == null)
+            {
+                throw new ArgumentNullException(nameof(b));
+            }
+
             var ad = a.Degree;
             var bd = b.Degree;
+
+            // 2020-10-07 jbialogrodzki #730 Zero polynomials need explicit handling.
+            // Without this check, we attempted to create arrays of negative lengths!
+            if (ad < 0 || bd < 0)
+            {
+                return Polynomial.Zero;
+            }
+
             double[] ac = a.Coefficients;
             double[] bc = b.Coefficients;
 
@@ -499,6 +583,7 @@ namespace MathNet.Numerics
             }
 
             return new Polynomial(result);
+
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #730 - the two cases mentioned in the original issue description. 

For polynomial evaluation, the issue affected a few variants of the API (double vs Complex), hopefully all are fixed and properly tested now.

Looking forward to getting this pulled and included in a release, so that I can get rid of the workarounds in my project. A big fan of Math.NET, and actually this was the first time it misbehaved... Keep it up!