### PR TITLE
Removed Dependency to Mathnet.Numerics.Properties Resources

### DIFF
--- a/src/Data/Matlab/Formatter.cs
+++ b/src/Data/Matlab/Formatter.cs
@@ -36,7 +36,6 @@ using System.Numerics;
 using System.Text;
 using MathNet.Numerics.LinearAlgebra;
 using MathNet.Numerics.LinearAlgebra.Storage;
-using MathNet.Numerics.Properties;
 
 namespace MathNet.Numerics.Data.Matlab
 {
@@ -73,7 +72,7 @@ namespace MathNet.Numerics.Data.Matlab
 #endif
             {
                 // write header and subsystem data offset (116+8 bytes)
-                var header = Encoding.ASCII.GetBytes(HeaderText + DateTime.Now.ToString(Resources.MatlabDateHeaderFormat));
+                var header = Encoding.ASCII.GetBytes(HeaderText + DateTime.Now.ToString("ddd MMM dd HH: mm:ss yyyy"));
                 writer.Write(header);
                 Pad(writer, 116 - header.Length + 8, 32);
 
@@ -117,12 +116,12 @@ namespace MathNet.Numerics.Data.Matlab
 
             if (string.IsNullOrEmpty(name))
             {
-                throw new ArgumentException(Resources.StringNullOrEmpty, "name");
+                throw new ArgumentException("String parameter cannot be empty or null.", "name");
             }
 
             if (name.IndexOf(' ') > -1)
             {
-                throw new ArgumentException(string.Format(Resources.NameCannotContainASpace, name), "name");
+                throw new ArgumentException(string.Format("Name cannot contain a space.name:  {0}", name), "name");
             }
 
             var dataType = typeof(T);

--- a/src/Data/Matlab/Parser.cs
+++ b/src/Data/Matlab/Parser.cs
@@ -36,7 +36,6 @@ using System.Numerics;
 using System.Text;
 using MathNet.Numerics.LinearAlgebra;
 using MathNet.Numerics.LinearAlgebra.Storage;
-using MathNet.Numerics.Properties;
 
 namespace MathNet.Numerics.Data.Matlab
 {
@@ -77,7 +76,7 @@ namespace MathNet.Numerics.Data.Matlab
                 // endian indicator (2 bytes)
                 if (reader.ReadByte() != LittleEndianIndicator)
                 {
-                    throw new NotSupportedException(Resources.BigEndianNotSupported);
+                    throw new NotSupportedException("Big endian files are not supported.");
                 }
 
                 // set position to first data element, right after full file header (128 bytes)
@@ -162,7 +161,7 @@ namespace MathNet.Numerics.Data.Matlab
                 var numDimensions = reader.ReadInt32()/8;
                 if (numDimensions > 2)
                 {
-                    throw new NotSupportedException(Resources.MoreThan2D);
+                    throw new NotSupportedException("Only 1 and 2 dimensional arrays are supported.");
                 }
 
                 // Dimensions Array data: row and column count (8 bytes)


### PR DESCRIPTION
I inlined the strings that were in the resources of Mathnet.Numerics in the Versions lower than 4.12.

This should fix Issue https://github.com/mathnet/mathnet-numerics/issues/727

This is my first PR, so please be gentle.