### PR TITLE
fix: Add NextBytes(Span<byte>) to RandomSource

### DIFF
--- a/src/Numerics/Random/RandomSource.cs
+++ b/src/Numerics/Random/RandomSource.cs
@@ -469,6 +469,27 @@ namespace MathNet.Numerics.Random
 
             DoSampleBytes(buffer);
         }
+        
+#if NETCOREAPP2_1_OR_GREATER
+        /// <summary>
+        /// Fills the elements of a specified array of bytes with random numbers.
+        /// </summary>
+        /// <param name="buffer">An array of bytes to contain random numbers.</param>
+        public sealed override void NextBytes(Span<byte> buffer)
+        {
+            if (_threadSafe)
+            {
+                lock (_lock)
+                {
+                    DoSampleBytes(buffer);
+                }
+
+                return;
+            }
+
+            DoSampleBytes(buffer);
+        }
+#endif
 
         /// <summary>
         /// Returns a random number between 0.0 and 1.0.
@@ -510,6 +531,18 @@ namespace MathNet.Numerics.Random
                 buffer[i] = (byte)(DoSampleInteger() % 256);
             }
         }
+
+#if NETCOREAPP2_1_OR_GREATER
+        /// <summary>
+        /// Fills the elements of a specified array of bytes with random numbers in full range, including zero and 255 (<see cref="F:System.Byte.MaxValue"/>).
+        /// </summary>
+        protected virtual void DoSampleBytes(Span<byte> buffer)
+        {
+            var temp = new byte[buffer.Length];
+            DoSampleBytes(temp);
+            temp.CopyTo(buffer);
+        }
+#endif
 
         /// <summary>
         /// Returns a random N-bit signed integer greater than or equal to zero and less than 2^N.


### PR DESCRIPTION
`RandomSource` does not inherit from `NextBytes (Span <byte>)` added in `.NET Core 2.1`, so I added it.
https://docs.microsoft.com/dotnet/api/system.random.nextbytes#System_Random_NextBytes_System_Span_System_Byte__