### PR TITLE
Resolve xoshiro256** out of range exception

### DIFF
--- a/src/Numerics.Tests/Random/RandomTests.cs
+++ b/src/Numerics.Tests/Random/RandomTests.cs
@@ -138,6 +138,20 @@ namespace MathNet.Numerics.UnitTests.Random
         }
 
         /// <summary>
+        /// NextBytes fills buffers of different sizes without throwing an exception (e.g. OutOfRangeException)
+        /// </remarks>
+        [Test]
+        public void NextBytesDoesNotThrow()
+        {
+            var rng = (System.Random)Activator.CreateInstance(_randomType, new object[] { false });
+
+            for (int i = 1; i < 30; i++)
+            {
+                Assert.DoesNotThrow(() => rng.NextBytes(new byte[i]));
+            }
+        }
+
+        /// <summary>
         /// Test runner function.
         /// </summary>
         /// <param name="random">RNG object.</param>

--- a/src/Numerics/Random/Xoshiro256StarStar.cs
+++ b/src/Numerics/Random/Xoshiro256StarStar.cs
@@ -158,7 +158,8 @@ namespace MathNet.Numerics.Random
             int i = 0;
 
             // Fill up the bulk of the buffer in chunks of 8 bytes at a time.
-            for (int bound = buffer.Length - 3; i < bound;)
+            int bound = buffer.Length - (buffer.Length % 8);
+            while (i < bound)
             {
                 // Generate 64 random bits.
                 ulong x = RotateLeft(s1 * 5, 7) * 9;


### PR DESCRIPTION
Fixes an OutOfRangeException thrown by the xoshiro256** implementation of DoSampleBytes when passed certain length buffers.

Also adds a related test for all random implementations to ensure they don't throw exceptions when calling NextBytes based on the length of the buffer. For xoshiro256** an OOR occurred depending on the buffer length mod 8.
- All PRNGs are passing the new test.

Fixes #664