### PR TITLE
Fix infinite loop in RandomExtensions.NextBigIntegerSequence(0,1)

### DIFF
--- a/src/Numerics.Tests/Random/RandomExtensionTests.cs
+++ b/src/Numerics.Tests/Random/RandomExtensionTests.cs
@@ -31,6 +31,7 @@ using MathNet.Numerics.Random;
 using NUnit.Framework;
 using System.Numerics;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace MathNet.Numerics.UnitTests.Random
 {
@@ -57,6 +58,7 @@ namespace MathNet.Numerics.UnitTests.Random
         public void CanSampleBigInteger()
         {
             var rnd = new System.Random(0);
+            //Main case
             IEnumerator<BigInteger> Sequence = rnd.NextBigIntegerSequence((BigInteger)long.MinValue * 3, (BigInteger)long.MaxValue * 3).GetEnumerator();
             Sequence.MoveNext();
             System.Console.WriteLine(Sequence.Current);
@@ -64,6 +66,8 @@ namespace MathNet.Numerics.UnitTests.Random
             System.Console.WriteLine(Sequence.Current);
             Sequence.MoveNext();
             System.Console.WriteLine(Sequence.Current);
+            //Boundary conditions
+            System.Console.WriteLine(rnd.NextBigIntegerSequence(0, 1).First());
         }
 
         /// <summary>

--- a/src/Numerics/Random/RandomExtensions.cs
+++ b/src/Numerics/Random/RandomExtensions.cs
@@ -203,7 +203,7 @@ namespace MathNet.Numerics.Random
         public static IEnumerable<BigInteger> NextBigIntegerSequence(this System.Random rnd, BigInteger minInclusive, BigInteger maxExclusive)
         {
             BigInteger AbsoluteRange = maxExclusive - minInclusive;
-            int NumBytes = (int)Math.Ceiling(BigInteger.Log(AbsoluteRange, byte.MaxValue) * 2);
+            int NumBytes = (int)Math.Ceiling(BigInteger.Log(AbsoluteRange, byte.MaxValue) * 2) + 1;
             byte[] ByteSequence = Enumerable.Repeat(byte.MaxValue, NumBytes + 1).ToArray();
             ByteSequence[NumBytes] = 0;
             BigInteger RandomNumber = new BigInteger(ByteSequence);


### PR DESCRIPTION
I found a boundary condition that falls into an infinite loop. Fixed.