### PR TITLE
Add path for DenseMatrix multiplication with SparseVector

### DIFF
--- a/src/Benchmark/LinearAlgebra/SparseVector.cs
+++ b/src/Benchmark/LinearAlgebra/SparseVector.cs
@@ -1,0 +1,64 @@
+﻿// <copyright file="SparseVector.cs" company="Math.NET">
+// Math.NET Numerics, part of the Math.NET Project
+// https://numerics.mathdotnet.com
+// https://github.com/mathnet/mathnet-numerics
+//
+// Copyright (c) 2009-$CURRENT_YEAR$ Math.NET
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+
+using BenchmarkDotNet.Attributes;
+using MathNet.Numerics.Distributions;
+using MathNet.Numerics.LinearAlgebra;
+using MathNet.Numerics.Random;
+using System.Linq;
+
+namespace Benchmark.LinearAlgebra
+{
+    public class SparseVector
+    {
+        private Matrix<double> matrix;
+        private Vector<double> vector;
+
+        [Params(100, 1000, 10000)]
+        public int N { get; set; }
+
+        [Params(0.01, 0.1, 0.5)]
+        public double SparseRatio { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            const int Seed = 42;
+
+            var rnd = new SystemRandomSource(Seed, true);
+
+            matrix = Matrix<double>.Build.Random(N, N, new Normal(rnd));
+
+            vector = Vector<double>.Build.SparseOfEnumerable(rnd.NextDoubleSequence().Take(N).Select(x => x < SparseRatio ? x : 0));
+        }
+
+        [Benchmark]
+        public Vector<double> DenseMatrixSparseVector() => matrix.Multiply(vector);
+    }
+}

--- a/src/Benchmark/Program.cs
+++ b/src/Benchmark/Program.cs
@@ -16,6 +16,7 @@ namespace Benchmark
                         typeof(Transforms.FFT),
                         typeof(LinearAlgebra.DenseMatrixProduct),
                         typeof(LinearAlgebra.DenseVector),
+                        typeof(LinearAlgebra.SparseVector),
                     });
 
             switcher.Run(args);

--- a/src/Numerics.Tests/LinearAlgebraTests/Complex/MatrixTests.Arithmetic.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Complex/MatrixTests.Arithmetic.cs
@@ -41,6 +41,28 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Complex
     /// </summary>
     public abstract partial class MatrixTests
     {
+        private static Vector<Complex> GetVector(string name, Complex[] data)
+        {
+            switch (name)
+            {
+                case "Dense": return Vector<Complex>.Build.Dense(data);
+                case "Sparse": return Vector<Complex>.Build.SparseOfArray(data);
+                case "User": return new UserDefinedVector(data);
+                default: throw new NotImplementedException($"{nameof(GetVector)}(string, Complex[]) for {nameof(name)}=\"{name}\"");
+            }
+        }
+
+        private static Vector<Complex> GetVector(string name, int size)
+        {
+            switch (name)
+            {
+                case "Dense": return Vector<Complex>.Build.Dense(size);
+                case "Sparse": return Vector<Complex>.Build.Sparse(size);
+                case "User": return new UserDefinedVector(size);
+                default: throw new NotImplementedException($"{nameof(GetVector)}(string, int) for {nameof(name)}=\"{name}\"");
+            }
+        }
+
         /// <summary>
         /// Can multiply with a complex number.
         /// </summary>
@@ -68,10 +90,10 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Complex
         /// Can multiply with a vector.
         /// </summary>
         [Test]
-        public void CanMultiplyWithVector()
+        public void CanMultiplyWithVector([Values("Dense", "Sparse", "User")] string vec)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = new DenseVector(new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
+            var x = GetVector(vec, new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
             var y = matrix * x;
 
             Assert.AreEqual(matrix.RowCount, y.Count);
@@ -88,11 +110,13 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Complex
         /// Can multiply with a vector into a result.
         /// </summary>
         [Test]
-        public void CanMultiplyWithVectorIntoResult()
+        public void CanMultiplyWithVectorIntoResult(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = new DenseVector(new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
-            var y = new DenseVector(3);
+            var x = GetVector(vecX, new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
+            var y = GetVector(vecY, 3);
             matrix.Multiply(x, y);
 
             for (var i = 0; i < matrix.RowCount; i++)
@@ -107,16 +131,18 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Complex
         /// Can multiply with a vector into result when updating input argument.
         /// </summary>
         [Test]
-        public void CanMultiplyWithVectorIntoResultWhenUpdatingInputArgument()
+        public void CanMultiplyWithVectorIntoResultWhenUpdatingInputArgument(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = new DenseVector(new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
+            var x = GetVector(vecX, new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
             var y = x;
             matrix.Multiply(x, x);
 
             Assert.AreSame(y, x);
 
-            y = new DenseVector(new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
+            y = GetVector(vecY, new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
             for (var i = 0; i < matrix.RowCount; i++)
             {
                 var ar = matrix.Row(i);
@@ -129,11 +155,13 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Complex
         /// Multiply with a vector into too large result throws <c>ArgumentException</c>.
         /// </summary>
         [Test]
-        public void MultiplyWithVectorIntoLargerResultThrowsArgumentException()
+        public void MultiplyWithVectorIntoLargerResultThrowsArgumentException(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = new DenseVector(new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
-            Vector<Complex> y = new DenseVector(4);
+            var x = GetVector(vecX, new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
+            var y = GetVector(vecY, 4);
             Assert.That(() => matrix.Multiply(x, y), Throws.ArgumentException);
         }
 
@@ -614,10 +642,10 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Complex
         /// Can multiply transposed matrix with a vector.
         /// </summary>
         [Test]
-        public void CanTransposeThisAndMultiplyWithVector()
+        public void CanTransposeThisAndMultiplyWithVector([Values("Dense", "Sparse", "User")] string vec)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = new DenseVector(new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
+            var x = GetVector(vec, new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
             var y = matrix.TransposeThisAndMultiply(x);
 
             Assert.AreEqual(matrix.ColumnCount, y.Count);
@@ -634,11 +662,13 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Complex
         /// Can multiply transposed matrix with a vector into a result.
         /// </summary>
         [Test]
-        public void CanTransposeThisAndMultiplyWithVectorIntoResult()
+        public void CanTransposeThisAndMultiplyWithVectorIntoResult(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = new DenseVector(new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
-            var y = new DenseVector(3);
+            var x = GetVector(vecX, new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
+            var y = GetVector(vecY, 3);
             matrix.TransposeThisAndMultiply(x, y);
 
             for (var j = 0; j < matrix.ColumnCount; j++)
@@ -653,16 +683,18 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Complex
         /// Can multiply transposed matrix with a vector into result when updating input argument.
         /// </summary>
         [Test]
-        public void CanTransposeThisAndMultiplyWithVectorIntoResultWhenUpdatingInputArgument()
+        public void CanTransposeThisAndMultiplyWithVectorIntoResultWhenUpdatingInputArgument(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = new DenseVector(new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
+            var x = GetVector(vecX, new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
             var y = x;
             matrix.TransposeThisAndMultiply(x, x);
 
             Assert.AreSame(y, x);
 
-            y = new DenseVector(new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
+            y = GetVector(vecY, new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
             for (var j = 0; j < matrix.ColumnCount; j++)
             {
                 var ar = matrix.Column(j);
@@ -675,12 +707,93 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Complex
         /// Multiply transposed matrix with a vector into too large result throws <c>ArgumentException</c>.
         /// </summary>
         [Test]
-        public void TransposeThisAndMultiplyWithVectorIntoLargerResultThrowsArgumentException()
+        public void TransposeThisAndMultiplyWithVectorIntoLargerResultThrowsArgumentException(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = new DenseVector(new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
-            Vector<Complex> y = new DenseVector(4);
+            var x = GetVector(vecX, new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
+            var y = GetVector(vecY, 4);
             Assert.That(() => matrix.TransposeThisAndMultiply(x, y), Throws.ArgumentException);
+        }
+
+        /// <summary>
+        /// Can multiply conjugate transposed matrix with a vector.
+        /// </summary>
+        [Test]
+        public void CanConjugateTransposeThisAndMultiplyWithVector([Values("Dense", "Sparse", "User")] string vec)
+        {
+            var matrix = TestMatrices["Singular3x3"];
+            var x = GetVector(vec, new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
+            var y = matrix.ConjugateTransposeThisAndMultiply(x);
+
+            Assert.AreEqual(matrix.ColumnCount, y.Count);
+
+            for (var j = 0; j < matrix.ColumnCount; j++)
+            {
+                var ar = matrix.Column(j);
+                var dot = ar.ConjugateDotProduct(x);
+                Assert.AreEqual(dot, y[j]);
+            }
+        }
+
+        /// <summary>
+        /// Can multiply conjugate transposed matrix with a vector into a result.
+        /// </summary>
+        [Test]
+        public void CanConjugateTransposeThisAndMultiplyWithVectorIntoResult(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
+        {
+            var matrix = TestMatrices["Singular3x3"];
+            var x = GetVector(vecX, new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
+            var y = GetVector(vecY, 3);
+            matrix.ConjugateTransposeThisAndMultiply(x, y);
+
+            for (var j = 0; j < matrix.ColumnCount; j++)
+            {
+                var ar = matrix.Column(j);
+                var dot = ar.ConjugateDotProduct(x);
+                Assert.AreEqual(dot, y[j]);
+            }
+        }
+
+        /// <summary>
+        /// Can multiply conjugate transposed matrix with a vector into result when updating input argument.
+        /// </summary>
+        [Test]
+        public void CanConjugateTransposeThisAndMultiplyWithVectorIntoResultWhenUpdatingInputArgument(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
+        {
+            var matrix = TestMatrices["Singular3x3"];
+            var x = GetVector(vecX, new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
+            var y = x;
+            matrix.ConjugateTransposeThisAndMultiply(x, x);
+
+            Assert.AreSame(y, x);
+
+            y = GetVector(vecY, new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
+            for (var j = 0; j < matrix.ColumnCount; j++)
+            {
+                var ar = matrix.Column(j);
+                var dot = ar.ConjugateDotProduct(y);
+                Assert.AreEqual(dot, x[j]);
+            }
+        }
+
+        /// <summary>
+        /// Multiply conjugate transposed matrix with a vector into too large result throws <c>ArgumentException</c>.
+        /// </summary>
+        [Test]
+        public void ConjugateTransposeThisAndMultiplyWithVectorIntoLargerResultThrowsArgumentException(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
+        {
+            var matrix = TestMatrices["Singular3x3"];
+            var x = GetVector(vecX, new[] { new Complex(1, 1), new Complex(2, 1), new Complex(3, 1) });
+            var y = GetVector(vecY, 4);
+            Assert.That(() => matrix.ConjugateTransposeThisAndMultiply(x, y), Throws.ArgumentException);
         }
 
         /// <summary>

--- a/src/Numerics.Tests/LinearAlgebraTests/Complex32/MatrixTests.Arithmetic.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Complex32/MatrixTests.Arithmetic.cs
@@ -42,6 +42,28 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Complex32
     /// </summary>
     public abstract partial class MatrixTests
     {
+        private static Vector<Complex32> GetVector(string name, Complex32[] data)
+        {
+            switch (name)
+            {
+                case "Dense": return Vector<Complex32>.Build.Dense(data);
+                case "Sparse": return Vector<Complex32>.Build.SparseOfArray(data);
+                case "User": return new UserDefinedVector(data);
+                default: throw new NotImplementedException($"{nameof(GetVector)}(string, Complex32[]) for {nameof(name)}=\"{name}\"");
+            }
+        }
+
+        private static Vector<Complex32> GetVector(string name, int size)
+        {
+            switch (name)
+            {
+                case "Dense": return Vector<Complex32>.Build.Dense(size);
+                case "Sparse": return Vector<Complex32>.Build.Sparse(size);
+                case "User": return new UserDefinedVector(size);
+                default: throw new NotImplementedException($"{nameof(GetVector)}(string, int) for {nameof(name)}=\"{name}\"");
+            }
+        }
+
         /// <summary>
         /// Can multiply with a complex number.
         /// </summary>
@@ -69,10 +91,10 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Complex32
         /// Can multiply with a vector.
         /// </summary>
         [Test]
-        public void CanMultiplyWithVector()
+        public void CanMultiplyWithVector([Values("Dense", "Sparse", "User")] string vec)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = new DenseVector(new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
+            var x = GetVector(vec, new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
             var y = matrix * x;
 
             Assert.AreEqual(matrix.RowCount, y.Count);
@@ -89,11 +111,13 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Complex32
         /// Can multiply with a vector into a result.
         /// </summary>
         [Test]
-        public void CanMultiplyWithVectorIntoResult()
+        public void CanMultiplyWithVectorIntoResult(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = new DenseVector(new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
-            var y = new DenseVector(3);
+            var x = GetVector(vecX, new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
+            var y = GetVector(vecY, 3);
             matrix.Multiply(x, y);
 
             for (var i = 0; i < matrix.RowCount; i++)
@@ -108,16 +132,18 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Complex32
         /// Can multiply with a vector into result when updating input argument.
         /// </summary>
         [Test]
-        public void CanMultiplyWithVectorIntoResultWhenUpdatingInputArgument()
+        public void CanMultiplyWithVectorIntoResultWhenUpdatingInputArgument(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = new DenseVector(new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
+            var x = GetVector(vecX, new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
             var y = x;
             matrix.Multiply(x, x);
 
             Assert.AreSame(y, x);
 
-            y = new DenseVector(new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
+            y = GetVector(vecY, new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
             for (var i = 0; i < matrix.RowCount; i++)
             {
                 var ar = matrix.Row(i);
@@ -130,11 +156,13 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Complex32
         /// Multiply with a vector into too large result throws <c>ArgumentException</c>.
         /// </summary>
         [Test]
-        public void MultiplyWithVectorIntoLargerResultThrowsArgumentException()
+        public void MultiplyWithVectorIntoLargerResultThrowsArgumentException(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = new DenseVector(new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
-            Vector<Complex32> y = new DenseVector(4);
+            var x = GetVector(vecX, new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
+            var y = GetVector(vecY, 4);
             Assert.That(() => matrix.Multiply(x, y), Throws.ArgumentException);
         }
 
@@ -615,10 +643,10 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Complex32
         /// Can multiply transposed matrix with a vector.
         /// </summary>
         [Test]
-        public void CanTransposeThisAndMultiplyWithVector()
+        public void CanTransposeThisAndMultiplyWithVector([Values("Dense", "Sparse", "User")] string vec)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = new DenseVector(new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
+            var x = GetVector(vec, new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
             var y = matrix.TransposeThisAndMultiply(x);
 
             Assert.AreEqual(matrix.ColumnCount, y.Count);
@@ -635,11 +663,13 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Complex32
         /// Can multiply transposed matrix with a vector into a result.
         /// </summary>
         [Test]
-        public void CanTransposeThisAndMultiplyWithVectorIntoResult()
+        public void CanTransposeThisAndMultiplyWithVectorIntoResult(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = new DenseVector(new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
-            var y = new DenseVector(3);
+            var x = GetVector(vecX, new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
+            var y = GetVector(vecY, 3);
             matrix.TransposeThisAndMultiply(x, y);
 
             for (var j = 0; j < matrix.ColumnCount; j++)
@@ -654,16 +684,18 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Complex32
         /// Can multiply transposed matrix with a vector into result when updating input argument.
         /// </summary>
         [Test]
-        public void CanTransposeThisAndMultiplyWithVectorIntoResultWhenUpdatingInputArgument()
+        public void CanTransposeThisAndMultiplyWithVectorIntoResultWhenUpdatingInputArgument(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = new DenseVector(new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
+            var x = GetVector(vecX, new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
             var y = x;
             matrix.TransposeThisAndMultiply(x, x);
 
             Assert.AreSame(y, x);
 
-            y = new DenseVector(new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
+            y = GetVector(vecY, new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
             for (var j = 0; j < matrix.ColumnCount; j++)
             {
                 var ar = matrix.Column(j);
@@ -676,12 +708,93 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Complex32
         /// Multiply transposed matrix with a vector into too large result throws <c>ArgumentException</c>.
         /// </summary>
         [Test]
-        public void TransposeThisAndMultiplyWithVectorIntoLargerResultThrowsArgumentException()
+        public void TransposeThisAndMultiplyWithVectorIntoLargerResultThrowsArgumentException(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = new DenseVector(new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
-            Vector<Complex32> y = new DenseVector(4);
+            var x = GetVector(vecX, new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
+            var y = GetVector(vecY, 4);
             Assert.That(() => matrix.TransposeThisAndMultiply(x, y), Throws.ArgumentException);
+        }
+
+        /// <summary>
+        /// Can multiply conjugate transposed matrix with a vector.
+        /// </summary>
+        [Test]
+        public void CanConjugateTransposeThisAndMultiplyWithVector([Values("Dense", "Sparse", "User")] string vec)
+        {
+            var matrix = TestMatrices["Singular3x3"];
+            var x = GetVector(vec, new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
+            var y = matrix.ConjugateTransposeThisAndMultiply(x);
+
+            Assert.AreEqual(matrix.ColumnCount, y.Count);
+
+            for (var j = 0; j < matrix.ColumnCount; j++)
+            {
+                var ar = matrix.Column(j);
+                var dot = ar.ConjugateDotProduct(x);
+                AssertHelpers.AlmostEqual(dot, y[j], 5);
+            }
+        }
+
+        /// <summary>
+        /// Can multiply conjugate transposed matrix with a vector into a result.
+        /// </summary>
+        [Test]
+        public void CanConjugateTransposeThisAndMultiplyWithVectorIntoResult(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
+        {
+            var matrix = TestMatrices["Singular3x3"];
+            var x = GetVector(vecX, new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
+            var y = GetVector(vecY, 3);
+            matrix.ConjugateTransposeThisAndMultiply(x, y);
+
+            for (var j = 0; j < matrix.ColumnCount; j++)
+            {
+                var ar = matrix.Column(j);
+                var dot = ar.ConjugateDotProduct(x);
+                AssertHelpers.AlmostEqual(dot, y[j], 5);
+            }
+        }
+
+        /// <summary>
+        /// Can multiply conjugate transposed matrix with a vector into result when updating input argument.
+        /// </summary>
+        [Test]
+        public void CanConjugateTransposeThisAndMultiplyWithVectorIntoResultWhenUpdatingInputArgument(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
+        {
+            var matrix = TestMatrices["Singular3x3"];
+            var x = GetVector(vecX, new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
+            var y = x;
+            matrix.ConjugateTransposeThisAndMultiply(x, x);
+
+            Assert.AreSame(y, x);
+
+            y = GetVector(vecY, new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
+            for (var j = 0; j < matrix.ColumnCount; j++)
+            {
+                var ar = matrix.Column(j);
+                var dot = ar.ConjugateDotProduct(y);
+                AssertHelpers.AlmostEqual(dot, x[j], 5);
+            }
+        }
+
+        /// <summary>
+        /// Multiply conjugate transposed matrix with a vector into too large result throws <c>ArgumentException</c>.
+        /// </summary>
+        [Test]
+        public void ConjugateTransposeThisAndMultiplyWithVectorIntoLargerResultThrowsArgumentException(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
+        {
+            var matrix = TestMatrices["Singular3x3"];
+            var x = GetVector(vecX, new[] { new Complex32(1, 1), new Complex32(2, 1), new Complex32(3, 1) });
+            var y = GetVector(vecY, 4);
+            Assert.That(() => matrix.ConjugateTransposeThisAndMultiply(x, y), Throws.ArgumentException);
         }
 
         /// <summary>

--- a/src/Numerics.Tests/LinearAlgebraTests/Double/MatrixTests.Arithmetic.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Double/MatrixTests.Arithmetic.cs
@@ -39,6 +39,28 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Double
     /// </summary>
     public abstract partial class MatrixTests
     {
+        private static Vector<double> GetVector(string name, double[] data)
+        {
+            switch (name)
+            {
+                case "Dense": return Vector<double>.Build.Dense(data);
+                case "Sparse": return Vector<double>.Build.SparseOfArray(data);
+                case "User": return new UserDefinedVector(data);
+                default: throw new NotImplementedException($"{nameof(GetVector)}(string, double[]) for {nameof(name)}=\"{name}\"");
+            }
+        }
+
+        private static Vector<double> GetVector(string name, int size)
+        {
+            switch (name)
+            {
+                case "Dense": return Vector<double>.Build.Dense(size);
+                case "Sparse": return Vector<double>.Build.Sparse(size);
+                case "User": return new UserDefinedVector(size);
+                default: throw new NotImplementedException($"{nameof(GetVector)}(string, int) for {nameof(name)}=\"{name}\"");
+            }
+        }
+
         /// <summary>
         /// Can multiply with a scalar.
         /// </summary>
@@ -65,10 +87,10 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Double
         /// Can multiply with a vector.
         /// </summary>
         [Test]
-        public void CanMultiplyWithVector()
+        public void CanMultiplyWithVector([Values("Dense", "Sparse", "User")] string vec)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = Vector<double>.Build.Dense(new[] { 1.0, 2.0, 3.0 });
+            var x = GetVector(vec, new[] { 1.0, 2.0, 3.0 });
             var y = matrix*x;
 
             Assert.AreEqual(matrix.RowCount, y.Count);
@@ -85,11 +107,13 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Double
         /// Can multiply with a vector into a result.
         /// </summary>
         [Test]
-        public void CanMultiplyWithVectorIntoResult()
+        public void CanMultiplyWithVectorIntoResult(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = Vector<double>.Build.Dense(new[] { 1.0, 2.0, 3.0 });
-            var y = Vector<double>.Build.Dense(3);
+            var x = GetVector(vecX, new[] { 1.0, 2.0, 3.0 });
+            var y = GetVector(vecY, 3);
             matrix.Multiply(x, y);
 
             for (var i = 0; i < matrix.RowCount; i++)
@@ -104,16 +128,18 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Double
         /// Can multiply with a vector into result when updating input argument.
         /// </summary>
         [Test]
-        public void CanMultiplyWithVectorIntoResultWhenUpdatingInputArgument()
+        public void CanMultiplyWithVectorIntoResultWhenUpdatingInputArgument(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = Vector<double>.Build.Dense(new[] { 1.0, 2.0, 3.0 });
+            var x = GetVector(vecX, new[] { 1.0, 2.0, 3.0 });
             var y = x;
             matrix.Multiply(x, x);
 
             Assert.AreSame(y, x);
 
-            y = Vector<double>.Build.Dense(new[] { 1.0, 2.0, 3.0 });
+            y = GetVector(vecY, new[] { 1.0, 2.0, 3.0 });
             for (var i = 0; i < matrix.RowCount; i++)
             {
                 var ar = matrix.Row(i);
@@ -126,11 +152,13 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Double
         /// Multiply with a vector into too large result throws <c>ArgumentException</c>.
         /// </summary>
         [Test]
-        public void MultiplyWithVectorIntoLargerResultThrowsArgumentException()
+        public void MultiplyWithVectorIntoLargerResultThrowsArgumentException(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = Vector<double>.Build.Dense(new[] { 1.0, 2.0, 3.0 });
-            Vector<double> y = Vector<double>.Build.Dense(4);
+            var x = GetVector(vecX, new[] { 1.0, 2.0, 3.0 });
+            var y = GetVector(vecY, 4);
             Assert.That(() => matrix.Multiply(x, y), Throws.ArgumentException);
         }
 
@@ -608,10 +636,10 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Double
         /// Can multiply transposed matrix with a vector.
         /// </summary>
         [Test]
-        public void CanTransposeThisAndMultiplyWithVector()
+        public void CanTransposeThisAndMultiplyWithVector([Values("Dense", "Sparse", "User")] string vec)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = Vector<double>.Build.Dense(new[] { 1.0, 2.0, 3.0 });
+            var x = GetVector(vec, new[] { 1.0, 2.0, 3.0 });
             var y = matrix.TransposeThisAndMultiply(x);
 
             Assert.AreEqual(matrix.ColumnCount, y.Count);
@@ -628,11 +656,13 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Double
         /// Can multiply transposed matrix with a vector into a result.
         /// </summary>
         [Test]
-        public void CanTransposeThisAndMultiplyWithVectorIntoResult()
+        public void CanTransposeThisAndMultiplyWithVectorIntoResult(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = Vector<double>.Build.Dense(new[] { 1.0, 2.0, 3.0 });
-            var y = Vector<double>.Build.Dense(3);
+            var x = GetVector(vecX, new[] { 1.0, 2.0, 3.0 });
+            var y = GetVector(vecY, 3);
             matrix.TransposeThisAndMultiply(x, y);
 
             for (var j = 0; j < matrix.ColumnCount; j++)
@@ -647,16 +677,18 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Double
         /// Can multiply transposed matrix with a vector into result when updating input argument.
         /// </summary>
         [Test]
-        public void CanTransposeThisAndMultiplyWithVectorIntoResultWhenUpdatingInputArgument()
+        public void CanTransposeThisAndMultiplyWithVectorIntoResultWhenUpdatingInputArgument(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = Vector<double>.Build.Dense(new[] { 1.0, 2.0, 3.0 });
+            var x = GetVector(vecX, new[] { 1.0, 2.0, 3.0 });
             var y = x;
             matrix.TransposeThisAndMultiply(x, x);
 
             Assert.AreSame(y, x);
 
-            y = Vector<double>.Build.Dense(new[] { 1.0, 2.0, 3.0 });
+            y = GetVector(vecY, new[] { 1.0, 2.0, 3.0 });
             for (var j = 0; j < matrix.ColumnCount; j++)
             {
                 var ar = matrix.Column(j);
@@ -669,11 +701,13 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Double
         /// Multiply transposed matrix with a vector into too large result throws <c>ArgumentException</c>.
         /// </summary>
         [Test]
-        public void TransposeThisAndMultiplyWithVectorIntoLargerResultThrowsArgumentException()
+        public void TransposeThisAndMultiplyWithVectorIntoLargerResultThrowsArgumentException(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = Vector<double>.Build.Dense(new[] { 1.0, 2.0, 3.0 });
-            Vector<double> y = Vector<double>.Build.Dense(4);
+            var x = GetVector(vecX, new[] { 1.0, 2.0, 3.0 });
+            var y = GetVector(vecY, 4);
             Assert.That(() => matrix.TransposeThisAndMultiply(x, y), Throws.ArgumentException);
         }
 

--- a/src/Numerics.Tests/LinearAlgebraTests/MatrixTests.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/MatrixTests.cs
@@ -116,5 +116,52 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests
             var result = SparseMatrix.OfDiagonalArray(new double[] { 10, 5, 2 });
             Assert.AreEqual(result, x);
         }
+
+        [Test]
+        public void MatrixVectorMultiplicationSameResult(
+            [Values("Dense", "Sparse")] string mtx,
+            [Values("Dense", "Sparse")] string vec,
+            [Values(0, 1, -1, double.Epsilon, double.MaxValue, double.MinValue, double.NaN, double.NegativeInfinity, double.PositiveInfinity)] double m_01,
+            [Values(0, 1, -1, double.Epsilon, double.MaxValue, double.MinValue, double.NaN, double.NegativeInfinity, double.PositiveInfinity)] double v_1
+            )
+        {
+            double m_00 = 1;
+            double m_10 = 0;
+            double m_11 = -2;
+
+            double v_0 = 0;
+
+            var matrixValues = new double[,] { { m_00, m_01 }, { m_10, m_11 } };
+            var vectorValues = new double[] { v_0, v_1 };
+
+            var m = GetMatrix(mtx, matrixValues);
+            var v = GetVector(vec, vectorValues);
+
+            var result = m * v;
+
+            Assert.AreEqual(2, result.Count, "Bad result dimension");
+            Assert.AreEqual((m_00 * v_0) + (m_01 * v_1), result[0], "Bad result index 0");
+            Assert.AreEqual((m_10 * v_0) + (m_11 * v_1), result[1], "Bad result index 1");
+        }
+
+        private static Matrix<double> GetMatrix(string name, double[,] data)
+        {
+            switch (name)
+            {
+                case "Dense": return Matrix<double>.Build.DenseOfArray(data);
+                case "Sparse": return Matrix<double>.Build.SparseOfArray(data);
+                default: throw new NotImplementedException($"{nameof(GetMatrix)}(string, double[,]) for {nameof(name)}=\"{name}\"");
+            }
+        }
+
+        private static Vector<double> GetVector(string name, double[] data)
+        {
+            switch (name)
+            {
+                case "Dense": return Vector<double>.Build.Dense(data);
+                case "Sparse": return Vector<double>.Build.SparseOfArray(data);
+                default: throw new NotImplementedException($"{nameof(GetVector)}(string, double[]) for {nameof(name)}=\"{name}\"");
+            }
+        }
     }
 }

--- a/src/Numerics.Tests/LinearAlgebraTests/Single/MatrixTests.Arithmetic.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Single/MatrixTests.Arithmetic.cs
@@ -40,6 +40,28 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Single
     /// </summary>
     public abstract partial class MatrixTests
     {
+        private static Vector<float> GetVector(string name, float[] data)
+        {
+            switch (name)
+            {
+                case "Dense": return Vector<float>.Build.Dense(data);
+                case "Sparse": return Vector<float>.Build.SparseOfArray(data);
+                case "User": return new UserDefinedVector(data);
+                default: throw new NotImplementedException($"{nameof(GetVector)}(string, float[]) for {nameof(name)}=\"{name}\"");
+            }
+        }
+
+        private static Vector<float> GetVector(string name, int size)
+        {
+            switch (name)
+            {
+                case "Dense": return Vector<float>.Build.Dense(size);
+                case "Sparse": return Vector<float>.Build.Sparse(size);
+                case "User": return new UserDefinedVector(size);
+                default: throw new NotImplementedException($"{nameof(GetVector)}(string, int) for {nameof(name)}=\"{name}\"");
+            }
+        }
+
         /// <summary>
         /// Can multiply with a scalar.
         /// </summary>
@@ -66,10 +88,10 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Single
         /// Can multiply with a vector.
         /// </summary>
         [Test]
-        public void CanMultiplyWithVector()
+        public void CanMultiplyWithVector([Values("Dense", "Sparse", "User")] string vec)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = new DenseVector(new[] { 1.0f, 2.0f, 3.0f });
+            var x = GetVector(vec, new[] { 1.0f, 2.0f, 3.0f });
             var y = matrix * x;
 
             Assert.AreEqual(matrix.RowCount, y.Count);
@@ -86,11 +108,13 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Single
         /// Can multiply with a vector into a result.
         /// </summary>
         [Test]
-        public void CanMultiplyWithVectorIntoResult()
+        public void CanMultiplyWithVectorIntoResult(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = new DenseVector(new[] { 1.0f, 2.0f, 3.0f });
-            var y = new DenseVector(3);
+            var x = GetVector(vecX, new[] { 1.0f, 2.0f, 3.0f });
+            var y = GetVector(vecY, 3);
             matrix.Multiply(x, y);
 
             for (var i = 0; i < matrix.RowCount; i++)
@@ -105,16 +129,18 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Single
         /// Can multiply with a vector into result when updating input argument.
         /// </summary>
         [Test]
-        public void CanMultiplyWithVectorIntoResultWhenUpdatingInputArgument()
+        public void CanMultiplyWithVectorIntoResultWhenUpdatingInputArgument(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = new DenseVector(new[] { 1.0f, 2.0f, 3.0f });
+            var x = GetVector(vecX, new[] { 1.0f, 2.0f, 3.0f });
             var y = x;
             matrix.Multiply(x, x);
 
             Assert.AreSame(y, x);
 
-            y = new DenseVector(new[] { 1.0f, 2.0f, 3.0f });
+            y = GetVector(vecY, new[] { 1.0f, 2.0f, 3.0f });
             for (var i = 0; i < matrix.RowCount; i++)
             {
                 var ar = matrix.Row(i);
@@ -127,11 +153,13 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Single
         /// Multiply with a vector into too large result throws <c>ArgumentException</c>.
         /// </summary>
         [Test]
-        public void MultiplyWithVectorIntoLargerResultThrowsArgumentException()
+        public void MultiplyWithVectorIntoLargerResultThrowsArgumentException(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = new DenseVector(new[] { 1.0f, 2.0f, 3.0f });
-            Vector<float> y = new DenseVector(4);
+            var x = GetVector(vecX, new[] { 1.0f, 2.0f, 3.0f });
+            var y = GetVector(vecY, 4);
             Assert.That(() => matrix.Multiply(x, y), Throws.ArgumentException);
         }
 
@@ -609,10 +637,10 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Single
         /// Can multiply transposed matrix with a vector.
         /// </summary>
         [Test]
-        public void CanTransposeThisAndMultiplyWithVector()
+        public void CanTransposeThisAndMultiplyWithVector([Values("Dense", "Sparse", "User")] string vec)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = new DenseVector(new[] { 1.0f, 2.0f, 3.0f });
+            var x = GetVector(vec, new[] { 1.0f, 2.0f, 3.0f });
             var y = matrix.TransposeThisAndMultiply(x);
 
             Assert.AreEqual(matrix.ColumnCount, y.Count);
@@ -627,11 +655,13 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Single
         /// Can multiply transposed matrix with a vector into a result.
         /// </summary>
         [Test]
-        public void CanTransposeThisAndMultiplyWithVectorIntoResult()
+        public void CanTransposeThisAndMultiplyWithVectorIntoResult(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = new DenseVector(new[] { 1.0f, 2.0f, 3.0f });
-            var y = new DenseVector(3);
+            var x = GetVector(vecX, new[] { 1.0f, 2.0f, 3.0f });
+            var y = GetVector(vecY, 3);
             matrix.TransposeThisAndMultiply(x, y);
 
             for (var j = 0; j < matrix.ColumnCount; j++)
@@ -644,16 +674,18 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Single
         /// Can multiply transposed matrix with a vector into result when updating input argument.
         /// </summary>
         [Test]
-        public void CanTransposeThisAndMultiplyWithVectorIntoResultWhenUpdatingInputArgument()
+        public void CanTransposeThisAndMultiplyWithVectorIntoResultWhenUpdatingInputArgument(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = new DenseVector(new[] { 1.0f, 2.0f, 3.0f });
+            var x = GetVector(vecX, new[] { 1.0f, 2.0f, 3.0f });
             var y = x;
             matrix.TransposeThisAndMultiply(x, x);
 
             Assert.AreSame(y, x);
 
-            y = new DenseVector(new[] { 1.0f, 2.0f, 3.0f });
+            y = GetVector(vecY, new[] { 1.0f, 2.0f, 3.0f });
             for (var j = 0; j < matrix.ColumnCount; j++)
             {
                 AssertHelpers.AlmostEqual(matrix.Column(j) * y, x[j], 6);
@@ -664,11 +696,13 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Single
         /// Multiply transposed matrix with a vector into too large result throws <c>ArgumentException</c>.
         /// </summary>
         [Test]
-        public void TransposeThisAndMultiplyWithVectorIntoLargerResultThrowsArgumentException()
+        public void TransposeThisAndMultiplyWithVectorIntoLargerResultThrowsArgumentException(
+            [Values("Dense", "Sparse", "User")] string vecX,
+            [Values("Dense", "Sparse", "User")] string vecY)
         {
             var matrix = TestMatrices["Singular3x3"];
-            var x = new DenseVector(new[] { 1.0f, 2.0f, 3.0f });
-            Vector<float> y = new DenseVector(4);
+            var x = GetVector(vecX, new[] { 1.0f, 2.0f, 3.0f });
+            var y = GetVector(vecY, 4);
             Assert.That(() => matrix.TransposeThisAndMultiply(x, y), Throws.ArgumentException);
         }
 

--- a/src/Numerics/LinearAlgebra/Complex/DenseMatrix.cs
+++ b/src/Numerics/LinearAlgebra/Complex/DenseMatrix.cs
@@ -598,11 +598,24 @@ namespace MathNet.Numerics.LinearAlgebra.Complex
                     denseRight.Count,
                     1,
                     denseResult.Values);
+                return;
             }
-            else
+
+            if (rightSide.Storage is SparseVectorStorage<Complex> sparseRight)
             {
-                base.DoMultiply(rightSide, result);
+                for (var i = 0; i < RowCount; i++)
+                {
+                    var s = Complex.Zero;
+                    for (var j = 0; j < sparseRight.ValueCount; j++)
+                    {
+                        s += At(i, sparseRight.Indices[j])*sparseRight.Values[j];
+                    }
+                    result[i] = s;
+                }
+                return;
             }
+
+            base.DoMultiply(rightSide, result);
         }
 
         /// <summary>
@@ -772,6 +785,20 @@ namespace MathNet.Numerics.LinearAlgebra.Complex
                 return;
             }
 
+            if (rightSide.Storage is SparseVectorStorage<Complex> sparseRight)
+            {
+                for (var j = 0; j < ColumnCount; j++)
+                {
+                    var s = Complex.Zero;
+                    for (var i = 0; i < sparseRight.ValueCount; i++)
+                    {
+                        s += At(sparseRight.Indices[i], j)*sparseRight.Values[i];
+                    }
+                    result[j] = s;
+                }
+                return;
+            }
+
             base.DoTransposeThisAndMultiply(rightSide, result);
         }
 
@@ -796,6 +823,19 @@ namespace MathNet.Numerics.LinearAlgebra.Complex
                     1,
                     0.0,
                     denseResult.Values);
+            }
+
+            if (rightSide.Storage is SparseVectorStorage<Complex> sparseRight)
+            {
+                for (var j = 0; j < ColumnCount; j++)
+                {
+                    var s = Complex.Zero;
+                    for (var i = 0; i < sparseRight.ValueCount; i++)
+                    {
+                        s += At(sparseRight.Indices[i], j).Conjugate()*sparseRight.Values[i];
+                    }
+                    result[j] = s;
+                }
                 return;
             }
 

--- a/src/Numerics/LinearAlgebra/Complex32/DenseMatrix.cs
+++ b/src/Numerics/LinearAlgebra/Complex32/DenseMatrix.cs
@@ -598,11 +598,24 @@ namespace MathNet.Numerics.LinearAlgebra.Complex32
                     denseRight.Count,
                     1,
                     denseResult.Values);
+                return;
             }
-            else
+
+            if (rightSide.Storage is SparseVectorStorage<Complex32> sparseRight)
             {
-                base.DoMultiply(rightSide, result);
+                for (var i = 0; i < RowCount; i++)
+                {
+                    var s = Complex32.Zero;
+                    for (var j = 0; j < sparseRight.ValueCount; j++)
+                    {
+                        s += At(i, sparseRight.Indices[j])*sparseRight.Values[j];
+                    }
+                    result[i] = s;
+                }
+                return;
             }
+
+            base.DoMultiply(rightSide, result);
         }
 
         /// <summary>
@@ -769,11 +782,24 @@ namespace MathNet.Numerics.LinearAlgebra.Complex32
                     1,
                     0.0f,
                     denseResult.Values);
+                return;
             }
-            else
+
+            if (rightSide.Storage is SparseVectorStorage<Complex32> sparseRight)
             {
-                base.DoTransposeThisAndMultiply(rightSide, result);
+                for (var j = 0; j < ColumnCount; j++)
+                {
+                    var s = Complex32.Zero;
+                    for (var i = 0; i < sparseRight.ValueCount; i++)
+                    {
+                        s += At(sparseRight.Indices[i], j)*sparseRight.Values[i];
+                    }
+                    result[j] = s;
+                }
+                return;
             }
+
+            base.DoTransposeThisAndMultiply(rightSide, result);
         }
 
         /// <summary>
@@ -797,6 +823,20 @@ namespace MathNet.Numerics.LinearAlgebra.Complex32
                     1,
                     0.0f,
                     denseResult.Values);
+                return;
+            }
+
+            if (rightSide.Storage is SparseVectorStorage<Complex32> sparseRight)
+            {
+                for (var j = 0; j < ColumnCount; j++)
+                {
+                    var s = Complex32.Zero;
+                    for (var i = 0; i < sparseRight.ValueCount; i++)
+                    {
+                        s += At(sparseRight.Indices[i], j).Conjugate()*sparseRight.Values[i];
+                    }
+                    result[j] = s;
+                }
                 return;
             }
 

--- a/src/Numerics/LinearAlgebra/Double/DenseMatrix.cs
+++ b/src/Numerics/LinearAlgebra/Double/DenseMatrix.cs
@@ -581,11 +581,24 @@ namespace MathNet.Numerics.LinearAlgebra.Double
                     denseRight.Count,
                     1,
                     denseResult.Values);
+                return;
             }
-            else
+
+            if (rightSide.Storage is SparseVectorStorage<double> sparseRight)
             {
-                base.DoMultiply(rightSide, result);
+                for (var i = 0; i < RowCount; i++)
+                {
+                    var s = 0.0;
+                    for (var j = 0; j < sparseRight.ValueCount; j++)
+                    {
+                        s += At(i, sparseRight.Indices[j])*sparseRight.Values[j];
+                    }
+                    result[i] = s;
+                }
+                return;
             }
+
+            base.DoMultiply(rightSide, result);
         }
 
         /// <summary>
@@ -699,11 +712,24 @@ namespace MathNet.Numerics.LinearAlgebra.Double
                     1,
                     0.0,
                     denseResult.Values);
+                return;
             }
-            else
+
+            if (rightSide.Storage is SparseVectorStorage<double> sparseRight)
             {
-                base.DoTransposeThisAndMultiply(rightSide, result);
+                for (var j = 0; j < ColumnCount; j++)
+                {
+                    var s = 0.0;
+                    for (var i = 0; i < sparseRight.ValueCount; i++)
+                    {
+                        s += At(sparseRight.Indices[i], j)*sparseRight.Values[i];
+                    }
+                    result[j] = s;
+                }
+                return;
             }
+
+            base.DoTransposeThisAndMultiply(rightSide, result);
         }
 
         /// <summary>

--- a/src/Numerics/LinearAlgebra/Single/DenseMatrix.cs
+++ b/src/Numerics/LinearAlgebra/Single/DenseMatrix.cs
@@ -581,11 +581,24 @@ namespace MathNet.Numerics.LinearAlgebra.Single
                     denseRight.Count,
                     1,
                     denseResult.Values);
+                return;
             }
-            else
+
+            if (rightSide.Storage is SparseVectorStorage<float> sparseRight)
             {
-                base.DoMultiply(rightSide, result);
+                for (var i = 0; i < RowCount; i++)
+                {
+                    var s = 0.0f;
+                    for (var j = 0; j < sparseRight.ValueCount; j++)
+                    {
+                        s += At(i, sparseRight.Indices[j])*sparseRight.Values[j];
+                    }
+                    result[i] = s;
+                }
+                return;
             }
+
+            base.DoMultiply(rightSide, result);
         }
 
         /// <summary>
@@ -699,11 +712,24 @@ namespace MathNet.Numerics.LinearAlgebra.Single
                     1,
                     0.0f,
                     denseResult.Values);
+                return;
             }
-            else
+
+            if (rightSide.Storage is SparseVectorStorage<float> sparseRight)
             {
-                base.DoTransposeThisAndMultiply(rightSide, result);
+                for (var j = 0; j < ColumnCount; j++)
+                {
+                    var s = 0.0f;
+                    for (var i = 0; i < sparseRight.ValueCount; i++)
+                    {
+                        s += At(sparseRight.Indices[i], j)*sparseRight.Values[i];
+                    }
+                    result[j] = s;
+                }
+                return;
             }
+
+            base.DoTransposeThisAndMultiply(rightSide, result);
         }
 
         /// <summary>


### PR DESCRIPTION
Currently when multiplying a `DenseMatrix` with a `Vector` there is a path to a `ILinearAlgebraProvider` when the multiplicand and the result are both `DenseVector`, otherwise we fall back to a base implementation:

https://github.com/mathnet/mathnet-numerics/blob/4b13ff4a5e7014997075df34a84d61f10bdd27b3/src/Numerics/LinearAlgebra/Double/Matrix.cs#L158-L169

When `rightSide` is a `SparseVector` then `rightSide[j]` is a binary search on the sparse indices. We can instead just iterate the sparse indices as the column indices, similar to the `DiagonalMatrix` path here:

https://github.com/mathnet/mathnet-numerics/blob/4b13ff4a5e7014997075df34a84d61f10bdd27b3/src/Numerics/LinearAlgebra/Double/DenseMatrix.cs#L611 

This PR does that in the second commit. The first commit tries to increase test coverage to make sure this path is tested. I wanted to add some tests to check arithmetic results are equal across different storage types (a generalisation of #912), I didn't achieve that but I think the changes add a little extra robustness in that area.

I ran a rudimentary benchmark in a distinctly unscientific environment (third commit, you may not want to take that) just for fun:
<pre><code>
BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.1766 (21H2)
Intel Xeon CPU E5-2640 v4 2.40GHz, 2 CPU, 8 logical and 8 physical cores
.NET SDK=6.0.302
  [Host]     : .NET 6.0.7 (6.0.722.32202), X64 RyuJIT
  DefaultJob : .NET 6.0.7 (6.0.722.32202), X64 RyuJIT
</code></pre>
|                           Method |     N | SparseRatio |               Mean |            Error |            StdDev |
|--------------------------------- |------ |------------ |-------------------:|-----------------:|------------------:|
| DenseMatrixSparseVector (before) |   100 |        0.01 |           216.2 μs |          7.15 μs |          20.86 μs |
| DenseMatrixSparseVector (after)  |   100 |        0.01 |             1.0 μs |          0.03 μs |           0.08 μs |
| DenseMatrixSparseVector (before) |   100 |         0.1 |           280.8 μs |          5.58 μs |          14.50 μs |
| DenseMatrixSparseVector (after)  |   100 |         0.1 |             4.2 μs |          0.13 μs |           0.37 μs |
| DenseMatrixSparseVector (before) |   100 |         0.5 |           356.9 μs |          6.99 μs |          11.87 μs |
| DenseMatrixSparseVector (after)  |   100 |         0.5 |            26.0 μs |          0.79 μs |           2.30 μs |
| DenseMatrixSparseVector (before) |  1000 |        0.01 |        36,249.2 μs |        942.81 μs |       2,765.10 μs |
| DenseMatrixSparseVector (after)  |  1000 |        0.01 |            44.6 μs |          1.50 μs |           4.47 μs |
| DenseMatrixSparseVector (before) |  1000 |         0.1 |        60,699.3 μs |      1,585.09 μs |       4,598.63 μs |
| DenseMatrixSparseVector (after)  |  1000 |         0.1 |           512.4 μs |         15.27 μs |          44.79 μs |
| DenseMatrixSparseVector (before) |  1000 |         0.5 |        87,900.7 μs |      1,782.12 μs |       5,170.26 μs |
| DenseMatrixSparseVector (after)  |  1000 |         0.5 |         3,109.7 μs |        104.21 μs |         307.28 μs |
| DenseMatrixSparseVector (before) | 10000 |        0.01 |     9,142,649.0 μs |    176,397.41 μs |     181,147.15 μs |
| DenseMatrixSparseVector (after)  | 10000 |        0.01 |         8,723.8 μs |        375.52 μs |       1,095.41 μs |
| DenseMatrixSparseVector (before) | 10000 |         0.1 |    11,304,746.1 μs |    253,185.38 μs |     734,536.69 μs |
| DenseMatrixSparseVector (after)  | 10000 |         0.1 |       109,569.1 μs |      3,059.45 μs |       8,924.56 μs |
| DenseMatrixSparseVector (before) | 10000 |         0.5 |    14,264,705.2 μs |    363,221.20 μs |   1,042,149.72 μs |
| DenseMatrixSparseVector (after)  | 10000 |         0.5 |     1,314,051.1 μs |     40,127.83 μs |     115,777.97 μs |