### PR TITLE
Fix initialisation bug in sparse matrix DoTransposeThisAndMultiply operation

### DIFF
--- a/src/Numerics/LinearAlgebra/Double/SparseMatrix.cs
+++ b/src/Numerics/LinearAlgebra/Double/SparseMatrix.cs
@@ -1162,6 +1162,7 @@ namespace MathNet.Numerics.LinearAlgebra.Double
         /// <param name="result">The result of the multiplication.</param>
         protected override void DoTransposeThisAndMultiply(Vector<double> rightSide, Vector<double> result)
         {
+            result.Clear();
             var rowPointers = _storage.RowPointers;
             var columnIndices = _storage.ColumnIndices;
             var values = _storage.Values;


### PR DESCRIPTION
The result vector needs to be zeroed before contributions from the non-zero elements of the sparse matrix are added to it.