### PR TITLE
Explicitly specify invariant culture in some unit tests

### DIFF
--- a/src/Data.Tests/Text/DelimitedWriterTests.cs
+++ b/src/Data.Tests/Text/DelimitedWriterTests.cs
@@ -142,7 +142,7 @@ namespace MathNet.Numerics.Data.Tests.Text
         {
             var matrix = SparseMatrix.OfArray(new[,] {{1.1, 0, 0}, {0, 5.5, 0}, {0, 0, 9.9}});
             var stream = new MemoryStream();
-            DelimitedWriter.Write(stream, matrix, " ");
+            DelimitedWriter.Write(stream, matrix, " ", formatProvider: CultureInfo.InvariantCulture);
             var data = stream.ToArray();
             var reader = new StreamReader(new MemoryStream(data));
             var text = reader.ReadToEnd();
@@ -160,7 +160,7 @@ namespace MathNet.Numerics.Data.Tests.Text
         {
             var matrix = SparseMatrix.OfArray(new[,] { { 1.1, 0, 0 }, { 0, 5.5, 0 }, { 0, 0, 9.9 } });
             var stream = new MemoryStream();
-            DelimitedWriter.Write(stream, matrix, ",", missingValue: 0);
+            DelimitedWriter.Write(stream, matrix, ",", missingValue: 0, formatProvider: CultureInfo.InvariantCulture);
             var data = stream.ToArray();
             var reader = new StreamReader(new MemoryStream(data));
             var text = reader.ReadToEnd();
@@ -179,7 +179,7 @@ namespace MathNet.Numerics.Data.Tests.Text
         {
             var matrix = DenseMatrix.OfArray(new[,] { { 1.1, double.NaN, 0 }, { 0, 5.5, 0 }, { double.NaN, double.NaN, 9.9 } });
             var stream = new MemoryStream();
-            DelimitedWriter.Write(stream, matrix, "\t", missingValue: double.NaN);
+            DelimitedWriter.Write(stream, matrix, "\t", missingValue: double.NaN, formatProvider: CultureInfo.InvariantCulture);
             var data = stream.ToArray();
             var reader = new StreamReader(new MemoryStream(data));
             var text = reader.ReadToEnd();

--- a/src/Numerics.Tests/LinearAlgebraTests/MatrixHelpers.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/MatrixHelpers.cs
@@ -28,6 +28,7 @@
 // </copyright>
 
 using System;
+using System.Globalization;
 using System.IO;
 using MathNet.Numerics.LinearAlgebra;
 using MathNet.Numerics.LinearAlgebra.Double;
@@ -136,7 +137,7 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests
                 if (!int.TryParse(split[1], out cooCols[i]))
                     throw new InvalidDataException($"Could not parse column integer on line {i + 1}");
 
-                if (!double.TryParse(split[2], out cooVals[i]))
+                if (!double.TryParse(split[2], NumberStyles.Float, CultureInfo.InvariantCulture, out cooVals[i]))
                     throw new InvalidDataException($"Could not parse double value on line {i + 1}");
 
                 nRows = Math.Max(nRows, cooRows[i] + 1);


### PR DESCRIPTION
The changes ensure that the unit tests pass on locales that do not use the period as decimal separator