### PR TITLE
Introduce a maxDeltaT to check if referencing points are within range

### DIFF
--- a/src/Numerics.Tests/InterpolationTests/LinearSplineTest.cs
+++ b/src/Numerics.Tests/InterpolationTests/LinearSplineTest.cs
@@ -138,5 +138,31 @@ namespace MathNet.Numerics.Tests.InterpolationTests
             Assert.That(() => LinearSpline.Interpolate(new double[1], new double[1]), Throws.ArgumentException);
             Assert.That(LinearSpline.Interpolate(new[] { 1.0, 2.0 }, new[] { 2.0, 2.0 }).Interpolate(1.0), Is.EqualTo(2.0));
         }
+
+        [TestCase(-2.4, .6, 1.5, 1e-15)]
+        [TestCase(-0.9, 1.7, 1.0, 1e-15)]
+        [TestCase(-0.5, .5, 1.0, 1e-15)]
+        [TestCase(-0.1, -.7, 1.0, 1e-15)]
+        [TestCase(0.1, -.9, 1.0, 1e-15)]
+        [TestCase(0.4, -.6, 1.0, 1e-15)]
+        [TestCase(1.2, .2, 1.0, 1e-15)]
+        [TestCase(10.0, 9.0, double.MaxValue, 1e-15)]
+        [TestCase(-10.0, -7.0, double.MaxValue, 1e-15)]
+        public void DeltaTCommonPoints(double t, double x, double maxDeltaT, double maxAbsoluteError)
+        {
+            LinearSpline ip = LinearSpline.Interpolate(_t, _y);
+            Assert.AreEqual(x, ip.Interpolate(t, maxDeltaT), maxAbsoluteError, "Interpolation at {0}", t);
+        }
+
+        [TestCase(0.1, -.9, 0.2)]
+        [TestCase(0.4, -.6, .2)]
+        [TestCase(1.2, .2, .2)]
+        [TestCase(10.0, 9.0, .2)]
+        [TestCase(-10.0, -7.0, .2)]
+        public void DeltaTPointTooNarrow(double t, double x, double maxDeltaT)
+        {
+            LinearSpline ip = LinearSpline.Interpolate(_t, _y);
+            Assert.Throws<InterpolatingDistanceException>(() => ip.Interpolate(t, maxDeltaT));
+        }
     }
 }

--- a/src/Numerics/Interpolation/LinearSpline.cs
+++ b/src/Numerics/Interpolation/LinearSpline.cs
@@ -130,8 +130,29 @@ namespace MathNet.Numerics.Interpolation
         /// <returns>Interpolated value x(t).</returns>
         public double Interpolate(double t)
         {
+            return Interpolate(t, double.MaxValue);
+        }
+
+        /// <summary>
+        /// Interpolate at point t.
+        /// </summary>
+        /// <param name="t">Point t to interpolate at.</param>
+        /// <param name="maxDeltaT">Maximum allowed delta between point 't' and reference points.</param>
+        /// <returns>Interpolated value x(t).</returns>
+        /// <exception cref="InterpolatingDistanceException">Thrown when distance from xn or xn+1 to 't' is exceeding <paramref name="maxDeltaT"/>.</exception>
+        public double Interpolate(double t, double maxDeltaT)
+        {
             int k = LeftSegmentIndex(t);
-            return _c0[k] + (t - _x[k])*_c1[k];
+
+            if (Math.Abs(t - _x[k]) > maxDeltaT)
+            {
+                throw new InterpolatingDistanceException("Lower bound point exceeds maxDetlaT.");
+            }
+            else if (Math.Abs(_x[k + 1] - t) > maxDeltaT)
+            {
+                throw new InterpolatingDistanceException("Upper bound point exceeds maxDetlaT.");
+            }
+            return _c0[k] + (t - _x[k]) * _c1[k];
         }
 
         /// <summary>


### PR DESCRIPTION
Hi @cdrnet,

I ran into a situation where I wanted to have the (LinearSpline) interpolation to fail when the two points used for interpolation are not within a certain range from point 't'.
I added a function which you can provide with a MaxDeltaT argument.

Please let me know if you'd like this addition for the library. It is currently implemented directly in LinearSpline, but I can imagine it might be worth for all interpolation functions. So if you like the idea I can extend it towards the IInterpolation Interface and implement it into all implementations.

Kind Regards Hylke