### PR TITLE
Add method with option to not allow extrapolation.

### DIFF
--- a/src/Numerics.Tests/InterpolationTests/LinearSplineTest.cs
+++ b/src/Numerics.Tests/InterpolationTests/LinearSplineTest.cs
@@ -29,6 +29,7 @@
 
 using MathNet.Numerics.Interpolation;
 using NUnit.Framework;
+using System;
 
 namespace MathNet.Numerics.Tests.InterpolationTests
 {
@@ -137,6 +138,18 @@ namespace MathNet.Numerics.Tests.InterpolationTests
             Assert.That(() => LinearSpline.Interpolate(new double[0], new double[0]), Throws.ArgumentException);
             Assert.That(() => LinearSpline.Interpolate(new double[1], new double[1]), Throws.ArgumentException);
             Assert.That(LinearSpline.Interpolate(new[] { 1.0, 2.0 }, new[] { 2.0, 2.0 }).Interpolate(1.0), Is.EqualTo(2.0));
+        }
+
+        [Test]
+        public void DoNotExtrapolate()
+        {
+            LinearSpline ip = LinearSpline.Interpolate(_t, _y);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => ip.Interpolate(-2.1, false));
+            Assert.Throws<ArgumentOutOfRangeException>(() => ip.Interpolate(10.0, false));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => LinearSpline.Interpolate(new[] { 1.0, 2.0 }, new[] { 2.0, 2.0 }).Interpolate(0.9, false));
+            Assert.Throws<ArgumentOutOfRangeException>(() => LinearSpline.Interpolate(new[] { 1.0, 2.0 }, new[] { 2.0, 2.0 }).Interpolate(3.0, false));
         }
     }
 }

--- a/src/Numerics/Interpolation/LinearSpline.cs
+++ b/src/Numerics/Interpolation/LinearSpline.cs
@@ -130,6 +130,24 @@ namespace MathNet.Numerics.Interpolation
         /// <returns>Interpolated value x(t).</returns>
         public double Interpolate(double t)
         {
+            return Interpolate(t, true);
+        }
+
+        /// <summary>
+        /// Interpolate at point t.
+        /// </summary>
+        /// <param name="t">Point t to interpolate at.</param>
+        /// <param name="allowExtrapolate">set to fals if extrapolate should not be allowed</param>
+        /// <returns>Interpolated value x(t).</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when t is outside range and would result in Extrapolation!</exception>
+        public double Interpolate(double t, bool allowExtrapolate)
+        {
+            if (!allowExtrapolate &&
+                (t < _x[0] || t > _x[_x.Length - 1]))
+            {
+                throw new ArgumentOutOfRangeException("'t' is outside of the constructed array. This would result in Extrapolation!");
+            }
+
             int k = LeftSegmentIndex(t);
             return _c0[k] + (t - _x[k])*_c1[k];
         }


### PR DESCRIPTION
Hi @cdrnet 

You library is great, however by default the interpolation functions also extrapolate, which is not always desired. Although I know a user is (in most cases) likely able to test possible extrapolation from outside the library, I thought it made a nice addition to the library.

I added a function (to LinearSpline) to which you can provide a flag to indicate whether extrapolation is allowed.

Please let me know if you'd like this addition for the library. It is currently implemented directly in LinearSpline, but I can imagine it might be worth for all interpolation functions. So if you like the idea I can extend it towards the IInterpolation Interface and implement it into all implementations.

Kind Regards,
Hylke