### PR TITLE
Bug in string description for mx0 and 0xn matrices

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -11,7 +11,7 @@
 * Random: xoshiro256StarStar fix out of range exception *~Charlie Turndorf*
 * Precision: Perf: pre-compute negative powers *~Febin*
 * Optimizations: Remove static properties in LevenbergMarquardtMinimizer *~Jong Hyun Kim*
-* Root Finding: Newton-Raphson better handling of zero-evaluations
+* Root Finding: Newton-Raphson better handling of zero-evaluations *~jkalias*
 * Fit.Curve and FindMinimum extended to accept two more parameters
 * Fixed an index out of bounds issue when calculating BFGS minimizer with one variable *~Shiney*
 * Fixed Sparse COO NormalizeDuplicates *~Mohamed Moussa*

--- a/src/Numerics.Tests/LinearAlgebraTests/Double/DenseMatrixTests.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Double/DenseMatrixTests.cs
@@ -95,6 +95,38 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Double
             Assert.AreEqual(10.0, data[0]);
         }
 
+        [Test]
+        public void DescriptionForMatrixWithRowsButNoColumns()
+        {
+            var matrix = TestMatrices["Tall3x2"];
+            matrix = matrix.RemoveColumn(matrix.ColumnCount - 1);
+            matrix = matrix.RemoveColumn(matrix.ColumnCount - 1);
+            Assert.AreEqual("DenseMatrix 3x0-Double\r\n[empty]\r\n[empty]\r\n[empty]\r\n", matrix.ToString());
+        }
+
+        [Test]
+        public void DescriptionForMatrixWithColumnsButNoRows()
+        {
+            var matrix = TestMatrices["Wide2x3"];
+            matrix = matrix.RemoveRow(matrix.RowCount - 1);
+            matrix = matrix.RemoveRow(matrix.RowCount - 1);
+            Assert.AreEqual("DenseMatrix 0x3-Double\r\n[empty]  [empty]  [empty]", matrix.ToString());
+        }
+
+        [Test]
+        public void DescriptionForMatrixWithNoRowsAndNoColumns()
+        {
+            var matrix = TestMatrices["Wide2x3"];
+            matrix = matrix.RemoveRow(matrix.RowCount - 1);
+            matrix = matrix.RemoveRow(matrix.RowCount - 1);
+
+            matrix = matrix.RemoveColumn(matrix.ColumnCount - 1);
+            matrix = matrix.RemoveColumn(matrix.ColumnCount - 1);
+            matrix = matrix.RemoveColumn(matrix.ColumnCount - 1);
+
+            Assert.AreEqual("DenseMatrix 0x0-Double\r\n[empty]", matrix.ToString());
+        }
+
         /// <summary>
         /// Matrix from two-dimensional array is a copy.
         /// </summary>

--- a/src/Numerics.Tests/LinearAlgebraTests/Double/DenseMatrixTests.cs
+++ b/src/Numerics.Tests/LinearAlgebraTests/Double/DenseMatrixTests.cs
@@ -98,18 +98,14 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Double
         [Test]
         public void DescriptionForMatrixWithRowsButNoColumns()
         {
-            var matrix = TestMatrices["Tall3x2"];
-            matrix = matrix.RemoveColumn(matrix.ColumnCount - 1);
-            matrix = matrix.RemoveColumn(matrix.ColumnCount - 1);
+            var matrix = GetMatrixWithRowsButNoColumns();
             Assert.AreEqual("DenseMatrix 3x0-Double\r\n[empty]\r\n[empty]\r\n[empty]\r\n", matrix.ToString());
         }
 
         [Test]
         public void DescriptionForMatrixWithColumnsButNoRows()
         {
-            var matrix = TestMatrices["Wide2x3"];
-            matrix = matrix.RemoveRow(matrix.RowCount - 1);
-            matrix = matrix.RemoveRow(matrix.RowCount - 1);
+            var matrix = GetMatrixWithColumnsButNoRows();
             Assert.AreEqual("DenseMatrix 0x3-Double\r\n[empty]  [empty]  [empty]", matrix.ToString());
         }
 
@@ -125,6 +121,15 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Double
             matrix = matrix.RemoveColumn(matrix.ColumnCount - 1);
 
             Assert.AreEqual("DenseMatrix 0x0-Double\r\n[empty]", matrix.ToString());
+        }
+
+        [Test]
+        public void MatrixMultiplicationWhenMatricesHaveNoRowsAndColumns()
+        {
+            var a = GetMatrixWithRowsButNoColumns();
+            var b = GetMatrixWithColumnsButNoRows();
+            var result = a * b;
+            Assert.AreEqual(new DenseMatrix(3), result);
         }
 
         /// <summary>
@@ -240,6 +245,22 @@ namespace MathNet.Numerics.Tests.LinearAlgebraTests.Double
                     GC.KeepAlive(m.ToMatrixString(i, j));
                 }
             }
+        }
+
+        private Matrix<double> GetMatrixWithRowsButNoColumns()
+        {
+            var matrix = TestMatrices["Tall3x2"];
+            matrix = matrix.RemoveColumn(matrix.ColumnCount - 1);
+            matrix = matrix.RemoveColumn(matrix.ColumnCount - 1);
+            return matrix;
+        }
+
+        private Matrix<double> GetMatrixWithColumnsButNoRows()
+        {
+            var matrix = TestMatrices["Wide2x3"];
+            matrix = matrix.RemoveRow(matrix.RowCount - 1);
+            matrix = matrix.RemoveRow(matrix.RowCount - 1);
+            return matrix;
         }
     }
 }

--- a/src/Numerics/LinearAlgebra/Matrix.BCL.cs
+++ b/src/Numerics/LinearAlgebra/Matrix.BCL.cs
@@ -279,7 +279,10 @@ namespace MathNet.Numerics.LinearAlgebra
             {
                 c[index++] = formatValue(At(row, column));
             }
-            int w = c.Max(x => x.Length);
+
+            int w = height != 0
+                ? c.Max(x => x.Length)
+                : 0;
             if (withEllipsis)
             {
                 c[upper] = ellipsis;
@@ -289,6 +292,7 @@ namespace MathNet.Numerics.LinearAlgebra
 
         static string FormatStringArrayToString(string[,] array, string columnSeparator, string rowSeparator)
         {
+            const string emptyString = "[empty]";
             var rows = array.GetLength(0);
             var cols = array.GetLength(1);
 
@@ -302,16 +306,46 @@ namespace MathNet.Numerics.LinearAlgebra
             }
 
             var sb = new StringBuilder();
-            for (int i = 0; i < rows; i++)
+            if (rows > 0)
             {
-                sb.Append(array[i, 0].PadLeft(widths[0]));
-                for (int j = 1; j < cols; j++)
+                for (int i = 0; i < rows; i++)
                 {
-                    sb.Append(columnSeparator);
-                    sb.Append(array[i, j].PadLeft(widths[j]));
+                    if (cols > 0)
+                    {
+                        sb.Append(array[i, 0].PadLeft(widths[0]));
+                        for (int j = 1; j < cols; j++)
+                        {
+                            sb.Append(columnSeparator);
+                            sb.Append(array[i, j].PadLeft(widths[j]));
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(emptyString);
+                    }
+
+                    sb.Append(rowSeparator);
                 }
-                sb.Append(rowSeparator);
             }
+            else
+            {
+                if (cols > 0)
+                {
+                    for (int j = 0; j < cols; j++)
+                    {
+                        sb.Append(emptyString);
+                        if (j != cols - 1)
+                        {
+                            sb.Append(columnSeparator);
+                        }
+                    }
+                }
+                else
+                {
+                    sb.Append(emptyString);
+                }
+            }
+
             return sb.ToString();
         }
 
@@ -319,18 +353,42 @@ namespace MathNet.Numerics.LinearAlgebra
             string horizontalEllipsis, string verticalEllipsis, string diagonalEllipsis,
             string columnSeparator, string rowSeparator, Func<T, string> formatValue)
         {
+            var array = ToMatrixStringArray(
+                upperRows,
+                lowerRows,
+                leftColumns,
+                rightColumns,
+                horizontalEllipsis,
+                verticalEllipsis,
+                diagonalEllipsis,
+                formatValue);
+
             return FormatStringArrayToString(
-                ToMatrixStringArray(upperRows, lowerRows, leftColumns, rightColumns, horizontalEllipsis, verticalEllipsis, diagonalEllipsis, formatValue),
-                columnSeparator, rowSeparator);
+                array,
+                columnSeparator,
+                rowSeparator);
         }
 
         public string ToMatrixString(int upperRows, int lowerRows, int minLeftColumns, int rightColumns, int maxWidth,
             string horizontalEllipsis, string verticalEllipsis, string diagonalEllipsis,
             string columnSeparator, string rowSeparator, Func<T, string> formatValue)
         {
+            var array = ToMatrixStringArray(
+                upperRows,
+                lowerRows,
+                minLeftColumns,
+                rightColumns,
+                maxWidth,
+                columnSeparator.Length,
+                horizontalEllipsis,
+                verticalEllipsis,
+                diagonalEllipsis,
+                formatValue);
+
             return FormatStringArrayToString(
-                ToMatrixStringArray(upperRows, lowerRows, minLeftColumns, rightColumns, maxWidth, columnSeparator.Length, horizontalEllipsis, verticalEllipsis, diagonalEllipsis, formatValue),
-                columnSeparator, rowSeparator);
+                array,
+                columnSeparator,
+                rowSeparator);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes crashes for matrices whose dimension can be zero (fixes #775 )