### PR TITLE
MKL linux build

### DIFF
--- a/src/NativeProviders/Linux/mkl_build.sh
+++ b/src/NativeProviders/Linux/mkl_build.sh
@@ -1,16 +1,17 @@
-#Note: g++ multilib must be installed
+Note: g++ multilib must be installed
+export VERSION=2023.1.0
 export INTEL=/opt/intel
-export MKL=$INTEL/mkl
-export OPENMP=$INTEL/lib
+export MKL=$INTEL/oneapi/mkl/$VERSION
+export OPENMP=$INTEL/oneapi/compiler/$VERSION/linux/compiler/lib
 export OUT=../../../out/MKL/Linux
 
 mkdir -p $OUT/x64
 mkdir -p $OUT/x86
 
-g++ -std=c++11 -D_M_X64 -DGCC -m64 --shared -fPIC -o $OUT/x64/libMathNetNumericsMKL.so -I$MKL/include -I../Common -I../MKL ../MKL/memory.c ../MKL/capabilities.cpp ../MKL/vector_functions.c ../Common/blas.c ../Common/lapack.cpp ../MKL/fft.cpp -Wl,--start-group  $MKL/lib/intel64/libmkl_intel_lp64.a $MKL/lib/intel64/libmkl_intel_thread.a $MKL/lib/intel64/libmkl_core.a -Wl,--end-group -L$OPENMP/intel64 -liomp5 -lpthread -lm  
+g++ -std=c++11 -D_M_X64 -DGCC -m64 --shared -fPIC -o $OUT/x64/libMathNetNumericsMKL.so -I$MKL/include -I../Common -I../MKL ../MKL/memory.c ../MKL/capabilities.cpp ../MKL/vector_functions.c ../Common/blas.c ../Common/lapack.cpp ../MKL/fft.cpp -Wl,--start-group  $MKL/lib/intel64/libmkl_intel_lp64.a $MKL/lib/intel64/libmkl_intel_thread.a $MKL/lib/intel64/libmkl_core.a -Wl,--end-group -L$OPENMP/intel64_lin -liomp5 -lpthread -lm
 
-cp $OPENMP/intel64/libiomp5.so  $OUT/x64/
+cp $OPENMP/intel64_lin/libiomp5.so  $OUT/x64/
 
-g++ -std=c++11 -D_M_IX86 -DGCC -m32 --shared -fPIC -o $OUT/x86/libMathNetNumericsMKL.so -I$MKL/include -I../Common -I../MKL ../MKL/memory.c ../MKL/capabilities.cpp ../MKL/vector_functions.c ../Common/blas.c ../Common/lapack.cpp ../MKL/fft.cpp  -Wl,--start-group $MKL/lib/ia32/libmkl_intel.a $MKL/lib/ia32/libmkl_intel_thread.a $MKL/lib/ia32/libmkl_core.a -Wl,--end-group -L$OPENMP/ia32 -liomp5 -lpthread -lm  
+g++ -std=c++11 -D_M_IX86 -DGCC -m32 --shared -fPIC -o $OUT/x86/libMathNetNumericsMKL.so -I$MKL/include -I../Common -I../MKL ../MKL/memory.c ../MKL/capabilities.cpp ../MKL/vector_functions.c ../Common/blas.c ../Common/lapack.cpp ../MKL/fft.cpp  -Wl,--start-group $MKL/lib/ia32/libmkl_intel.a $MKL/lib/ia32/libmkl_intel_thread.a $MKL/lib/ia32/libmkl_core.a -Wl,--end-group -L$OPENMP/ia32_lin -liomp5 -lpthread -lm
 
-cp $OPENMP/ia32/libiomp5.so  $OUT/x86/
+cp $OPENMP/ia32_lin/libiomp5.so  $OUT/x86/

--- a/src/NativeProviders/Linux/readme.txt
+++ b/src/NativeProviders/Linux/readme.txt
@@ -1,10 +1,11 @@
-Install MKL:
-tar -zxvf l_mkl_11.3.0.109.tgz
-sudo ./install.sh
-Make sure to include IA32 as well
+1) Install MKL.
 
-Install g++:
+There are many options. At time of writing this is a good source:
+https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl-download.html
+
+2) Install g++:
 sudo apt-get install g++ g++-multilib libc6-dev-i386
 
-Build:
+3) Build:
 ./mkl_build.sh
+PS: you may have to update MKL's version number inside the script. See VERSION environment variable.


### PR DESCRIPTION
I'm using MathNet with MKL on Linux. I had to make these changes to build with the latest MKL.
The current MKL for Linux library in the nugget package is too old and MathNet doesn't accept it.