### PR TITLE
Modified newtons method

### DIFF
--- a/src/Numerics.Tests/OptimizationTests/NewtonMinimizerTests.cs
+++ b/src/Numerics.Tests/OptimizationTests/NewtonMinimizerTests.cs
@@ -84,48 +84,30 @@ namespace MathNet.Numerics.Tests.OptimizationTests
         }
     }
 
-    public class LazyBealebjectiveFunction : LazyObjectiveFunctionBase
+    public class LazySixHumpCamelObjectiveFunction : LazyObjectiveFunctionBase
     {
-        public LazyBealebjectiveFunction() : base(true, true) { }
+        public LazySixHumpCamelObjectiveFunction() : base(true, true) { }
 
         public override IObjectiveFunction CreateNew()
         {
-            return new LazyBealebjectiveFunction();
+            return new LazySixHumpCamelObjectiveFunction();
         }
 
         protected override void EvaluateValue()
         {
-            Value = BealeFunction2D.Value(Point);
+            Value = SixHumpCamelFunction.Value(Point);
         }
 
         protected override void EvaluateGradient()
         {
-            Gradient = BealeFunction2D.Gradient(Point);
+            Gradient = SixHumpCamelFunction.Gradient(Point);
         }
 
         protected override void EvaluateHessian()
         {
-            Hessian = BealeFunction2D.Hessian(Point);
-        }
-    }
-
-    public class BealeObjectiveFunction : ObjectiveFunctionBase
-    {
-        public BealeObjectiveFunction() : base(true, true) { }
-
-        public override IObjectiveFunction CreateNew()
-        {
-            return new BealeObjectiveFunction();
+            Hessian = SixHumpCamelFunction.Hessian(Point);
         }
 
-        protected override void Evaluate()
-        {
-            // here we could directly overwrite the existing matrix cells instead.
-            // note: values must then be initialized manually first, if null.
-            Value = BealeFunction2D.Value(Point); ;
-            Gradient = BealeFunction2D.Gradient(Point);
-            Hessian = BealeFunction2D.Hessian(Point);
-        }
     }
 
     [TestFixture]
@@ -198,14 +180,14 @@ namespace MathNet.Numerics.Tests.OptimizationTests
         }
 
         [Test]
-        public void FindMinimum_Beale_IndefiniteHessian()
+        public void FindMinimum_SixHumpCamel_IndefiniteHessian()
         {
-            var obj = new LazyBealebjectiveFunction();
+            var obj = new LazySixHumpCamelObjectiveFunction();
             var solver = new NewtonMinimizer(1e-5, 1000, true);
-            var result = solver.FindMinimum(obj, new DenseVector(new double[] { 4, 0.9 }));
+            var result = solver.FindMinimum(obj, new DenseVector(new double[] { 1.0, -0.6 }));
 
-            Assert.That(Math.Abs(result.MinimizingPoint[0] - 3.0), Is.LessThan(1e-3));
-            Assert.That(Math.Abs(result.MinimizingPoint[1] - 0.5), Is.LessThan(1e-3));
+            Assert.That(result.MinimizingPoint[0], Is.EqualTo(0.0898).Within(1e-3));
+            Assert.That(result.MinimizingPoint[1], Is.EqualTo(-0.7126).Within(1e-3));
         }
 
         private class MghTestCaseEnumerator : IEnumerable<ITestCaseData>

--- a/src/Numerics.Tests/OptimizationTests/NewtonMinimizerTests.cs
+++ b/src/Numerics.Tests/OptimizationTests/NewtonMinimizerTests.cs
@@ -183,7 +183,7 @@ namespace MathNet.Numerics.Tests.OptimizationTests
         public void FindMinimum_SixHumpCamel_IndefiniteHessian()
         {
             var obj = new LazySixHumpCamelObjectiveFunction();
-            var solver = new NewtonMinimizer(1e-5, 1000, true);
+            var solver = new NewtonMinimizer(1e-5, 1000, true, HessianModifiers.ReverseNegativeEigenValues);
             var result = solver.FindMinimum(obj, new DenseVector(new double[] { 1.0, -0.6 }));
 
             Assert.That(result.MinimizingPoint[0], Is.EqualTo(0.0898).Within(1e-3));

--- a/src/Numerics.Tests/OptimizationTests/TestFunctions/BealeFunction2D.cs
+++ b/src/Numerics.Tests/OptimizationTests/TestFunctions/BealeFunction2D.cs
@@ -1,0 +1,98 @@
+﻿// <copyright file="BealeFunction2D.cs" company="Math.NET">
+// Math.NET Numerics, part of the Math.NET Project
+// https://numerics.mathdotnet.com
+// https://github.com/mathnet/mathnet-numerics
+//
+// Copyright (c) 2009-$CURRENT_YEAR$ Math.NET
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+
+using System;
+using MathNet.Numerics.LinearAlgebra;
+using MathNet.Numerics.LinearAlgebra.Double;
+
+namespace MathNet.Numerics.Tests.OptimizationTests.TestFunctions
+{
+    public static  class BealeFunction2D
+    {
+        public static double Value(Vector<double> input)
+        {
+            double x = input[0];
+            double y = input[1];
+
+            double a = 1.5 - x + x * y;
+            double b = 2.25 - x + x * y * y;
+            double c = 2.625 - x + x * Math.Pow(y, 3);
+
+            return Math.Pow(a, 2) + Math.Pow(b, 2) + Math.Pow(c, 2);
+        }
+
+        public static Vector<double> Gradient(Vector<double> input)
+        {
+            double x = input[0];
+            double y = input[1];
+
+            double a = 1.5 - x + x * y;
+            double b = 2.25 - x + x * y * y;
+            double c = 2.625 - x + x * Math.Pow(y, 3);
+
+            Vector<double> output = new DenseVector(2);
+
+            output[0] = 2 * (y - 1) * a + 2 * (y * y - 1) * b + 2 * (Math.Pow(y, 3) - 1) * c;
+            output[1] = 2 * x * a + 4 * x * y * b + 6 * x * y * y * c;
+            return output;
+        }
+
+        public static Matrix<double> Hessian(Vector<double> input)
+        {
+            double x = input[0];
+            double y = input[1];
+
+            double a = 1.5 - x + x * y;
+            double axprime = y - 1;
+
+            double b = 2.25 - x + x * y * y;
+            double bxprime = y * y - 1;
+
+            double c = 2.625 - x + x * Math.Pow(y, 3);
+            double cxprime = Math.Pow(y, 3) - 1;
+
+
+            Matrix<double> output = new DenseMatrix(2, 2);
+            output[0, 0] = 2 * (Math.Pow(axprime, 2) + Math.Pow(bxprime, 2) + Math.Pow(cxprime, 2));
+            output[1, 1] = 2 * Math.Pow(x, 2) + 8 * Math.Pow(x, 2) * Math.Pow(y, 2) + 18 * Math.Pow(x, 2) * Math.Pow(y, 4) + 4 * x * b + 12 * x * y * c;
+            output[0, 1] = 2 * x * axprime + 2 * a + 4 * x * y * bxprime + 4 * y * b + 6 * x * Math.Pow(y, 2) * cxprime + 6 * Math.Pow(y, 2) * c;
+            output[1, 0] = output[0, 1];
+            return output;
+        }
+
+        public static Vector<double> Minimum
+        {
+            get
+            {
+                return new DenseVector(new double[] { 3, 0.5 });
+            }
+        }
+    }
+}
+

--- a/src/Numerics.Tests/OptimizationTests/TestFunctions/SixHumpCamelFunction.cs
+++ b/src/Numerics.Tests/OptimizationTests/TestFunctions/SixHumpCamelFunction.cs
@@ -32,6 +32,9 @@ using MathNet.Numerics.LinearAlgebra.Double;
 
 namespace MathNet.Numerics.Tests.OptimizationTests.TestFunctions
 {
+    /// <summary>
+    /// Six-Hump Camel Function, see http://www.sfu.ca/~ssurjano/camel6.html for formula and global minimum locations
+    /// </summary>
     public static class SixHumpCamelFunction
     {
         public static double Value(Vector<double> input)

--- a/src/Numerics.Tests/OptimizationTests/TestFunctions/SixHumpCamelFunction.cs
+++ b/src/Numerics.Tests/OptimizationTests/TestFunctions/SixHumpCamelFunction.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="BealeFunction2D.cs" company="Math.NET">
+﻿// <copyright file="SixHumpCamelFunction.cs" company="Math.NET">
 // Math.NET Numerics, part of the Math.NET Project
 // https://numerics.mathdotnet.com
 // https://github.com/mathnet/mathnet-numerics
@@ -27,24 +27,23 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 // </copyright>
 
-using System;
 using MathNet.Numerics.LinearAlgebra;
 using MathNet.Numerics.LinearAlgebra.Double;
 
 namespace MathNet.Numerics.Tests.OptimizationTests.TestFunctions
 {
-    public static  class BealeFunction2D
+    public static class SixHumpCamelFunction
     {
         public static double Value(Vector<double> input)
         {
             double x = input[0];
             double y = input[1];
 
-            double a = 1.5 - x + x * y;
-            double b = 2.25 - x + x * y * y;
-            double c = 2.625 - x + x * Math.Pow(y, 3);
+            double x2 = x * x;
+            double x4 = x * x * x * x;
+            double y2 = y * y;
 
-            return Math.Pow(a, 2) + Math.Pow(b, 2) + Math.Pow(c, 2);
+            return x2 * (4 - 2.1 * x2 + x4 / 3) + x * y + 4 * y2 * (y2 - 1);
         }
 
         public static Vector<double> Gradient(Vector<double> input)
@@ -52,14 +51,15 @@ namespace MathNet.Numerics.Tests.OptimizationTests.TestFunctions
             double x = input[0];
             double y = input[1];
 
-            double a = 1.5 - x + x * y;
-            double b = 2.25 - x + x * y * y;
-            double c = 2.625 - x + x * Math.Pow(y, 3);
+            double x3 = x * x * x;
+            double x5 = x * x * x * x * x;
+            double y2 = y * y;
+            double y3 = y * y * y;           
 
             Vector<double> output = new DenseVector(2);
 
-            output[0] = 2 * (y - 1) * a + 2 * (y * y - 1) * b + 2 * (Math.Pow(y, 3) - 1) * c;
-            output[1] = 2 * x * a + 4 * x * y * b + 6 * x * y * y * c;
+            output[0] = 2 * (4 * x - 4.2 * x3 + x5 + 0.5 * y);
+            output[1] = x - 8 * y + 16 * y3;
             return output;
         }
 
@@ -68,20 +68,15 @@ namespace MathNet.Numerics.Tests.OptimizationTests.TestFunctions
             double x = input[0];
             double y = input[1];
 
-            double a = 1.5 - x + x * y;
-            double axprime = y - 1;
-
-            double b = 2.25 - x + x * y * y;
-            double bxprime = y * y - 1;
-
-            double c = 2.625 - x + x * Math.Pow(y, 3);
-            double cxprime = Math.Pow(y, 3) - 1;
+            double x2 = x * x;
+            double x4 = x * x * x * x;
+            double y2 = y * y;
 
 
             Matrix<double> output = new DenseMatrix(2, 2);
-            output[0, 0] = 2 * (Math.Pow(axprime, 2) + Math.Pow(bxprime, 2) + Math.Pow(cxprime, 2));
-            output[1, 1] = 2 * Math.Pow(x, 2) + 8 * Math.Pow(x, 2) * Math.Pow(y, 2) + 18 * Math.Pow(x, 2) * Math.Pow(y, 4) + 4 * x * b + 12 * x * y * c;
-            output[0, 1] = 2 * x * axprime + 2 * a + 4 * x * y * bxprime + 4 * y * b + 6 * x * Math.Pow(y, 2) * cxprime + 6 * Math.Pow(y, 2) * c;
+            output[0, 0] = 10 * (0.8 - 2.52 * x2 + x4);
+            output[1, 1] = 48 * y2 - 8;
+            output[0, 1] = 1;
             output[1, 0] = output[0, 1];
             return output;
         }
@@ -90,9 +85,8 @@ namespace MathNet.Numerics.Tests.OptimizationTests.TestFunctions
         {
             get
             {
-                return new DenseVector(new double[] { 3, 0.5 });
+                return new DenseVector(new double[] { 0.0898, -0.7126 });
             }
         }
     }
 }
-

--- a/src/Numerics/Optimization/HessianModifiers.cs
+++ b/src/Numerics/Optimization/HessianModifiers.cs
@@ -1,0 +1,43 @@
+﻿// <copyright file="HessianModifiers.cs" company="Math.NET">
+// Math.NET Numerics, part of the Math.NET Project
+// https://numerics.mathdotnet.com
+// https://github.com/mathnet/mathnet-numerics
+//
+// Copyright (c) 2009-$CURRENT_YEAR$ Math.NET
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MathNet.Numerics.Optimization
+{
+    public enum HessianModifiers
+    {
+        None,
+        ReverseNegativeEigenValues
+    }
+}

--- a/src/Numerics/Optimization/NewtonMinimizer.cs
+++ b/src/Numerics/Optimization/NewtonMinimizer.cs
@@ -149,6 +149,12 @@ namespace MathNet.Numerics.Optimization
             return objective.Hessian.LU().Solve(-objective.Gradient);
         }
 
+        /// <summary>
+        /// Force the Hessian to be positive definite by reversing the negative eigenvalues. Use the EVD decomposition to then solve for the search direction.
+        /// Implementation based on Philip E. Gill, Walter Murray, and Margaret H. Wright, Practical Optimization, 1981, 107–8.
+        /// </summary>
+        /// <param name="objective"></param>
+        /// <returns></returns>
         static Vector<double> ReverseNegativeEigenValuesAndSolve(IObjectiveFunction objective)
         {
             Evd<double> evd = objective.Hessian.Evd(Symmetricity.Symmetric);

--- a/src/Numerics/Optimization/NewtonMinimizer.cs
+++ b/src/Numerics/Optimization/NewtonMinimizer.cs
@@ -151,15 +151,15 @@ namespace MathNet.Numerics.Optimization
 
         static Vector<double> ReverseNegativeEigenValuesAndSolve(IObjectiveFunction objective)
         {
-            Evd<double> oEVD = objective.Hessian.Evd(Symmetricity.Symmetric);
-            for (int i = 0; i < oEVD.EigenValues.Count; i++)
+            Evd<double> evd = objective.Hessian.Evd(Symmetricity.Symmetric);
+            for (int i = 0; i < evd.EigenValues.Count; i++)
             {
-                if (oEVD.EigenValues[i].Real < double.Epsilon)
+                if (evd.EigenValues[i].Real < double.Epsilon)
                 {
-                    oEVD.EigenValues[i] = Math.Max(-oEVD.EigenValues[i].Real, double.Epsilon);
+                    evd.EigenValues[i] = Math.Max(-evd.EigenValues[i].Real, double.Epsilon);
                 }
             }
-            return oEVD.Solve(-objective.Gradient);
+            return evd.Solve(-objective.Gradient);
         }
 
         static void ValidateGradient(IObjectiveFunctionEvaluation eval)


### PR DESCRIPTION
My proposed solution to #1067 (which I also submitted).

I added an option to Newton Minimizer which forces the Hessian to be positive definite by reversing negative eigenvalues. This method is described in 

Philip E. Gill, Walter Murray, and Margaret H. Wright, Practical Optimization, 1981, 107–8.

I also added a unit test, FindMinimum_SixHumpCamel_IndefiniteHessian(), to demonstrate the benefit of this modification. If the optional argument is changed to HessianModifiers.None then the test fails.

Please see the issue for further illustration of the use case.

I made the optional argument an enum because this method of forcing positive definiteness can be improved upon in terms of efficiency and this gives some future developer the hooks to be able to do so.

Regards,
Mikhail
