### PR TITLE
Add ILeastSquaresMinimizer interface

### DIFF
--- a/src/Numerics/Optimization/ILeastSquaresMinimizer.cs
+++ b/src/Numerics/Optimization/ILeastSquaresMinimizer.cs
@@ -1,0 +1,67 @@
+﻿// <copyright file="ILeastSquaresMinimizer.cs" company="Math.NET">
+// Math.NET Numerics, part of the Math.NET Project
+// https://numerics.mathdotnet.com
+// https://github.com/mathnet/mathnet-numerics
+//
+// Copyright (c) 2009-$CURRENT_YEAR$ Math.NET
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+
+using MathNet.Numerics.LinearAlgebra;
+using System.Collections.Generic;
+
+namespace MathNet.Numerics.Optimization
+{
+    /// <summary>
+    /// Interface for solving nonlinear least squares problems.
+    /// This interface unifies the Levenberg-Marquardt and Trust Region minimization algorithms.
+    /// </summary>
+    public interface ILeastSquaresMinimizer
+    {
+        /// <summary>
+        /// Finds the minimum of a nonlinear least squares problem using the specified objective model and initial guess vector.
+        /// </summary>
+        /// <param name="objective">The objective function model to be minimized.</param>
+        /// <param name="initialGuess">The initial guess vector.</param>
+        /// <param name="lowerBound">Optional lower bound for the parameters.</param>
+        /// <param name="upperBound">Optional upper bound for the parameters.</param>
+        /// <param name="scales">Optional scales for the parameters.</param>
+        /// <param name="isFixed">Optional list indicating which parameters are fixed.</param>
+        /// <returns>A <see cref="NonlinearMinimizationResult"/> containing the results of the minimization.</returns>
+        NonlinearMinimizationResult FindMinimum(IObjectiveModel objective, Vector<double> initialGuess,
+            Vector<double> lowerBound = null, Vector<double> upperBound = null, Vector<double> scales = null, List<bool> isFixed = null);
+
+        /// <summary>
+        /// Finds the minimum of a nonlinear least squares problem using the specified objective model and initial guess array.
+        /// </summary>
+        /// <param name="objective">The objective function model to be minimized.</param>
+        /// <param name="initialGuess">The initial guess array.</param>
+        /// <param name="lowerBound">Optional lower bound array for the parameters.</param>
+        /// <param name="upperBound">Optional upper bound array for the parameters.</param>
+        /// <param name="scales">Optional scales array for the parameters.</param>
+        /// <param name="isFixed">Optional array indicating which parameters are fixed.</param>
+        /// <returns>A <see cref="NonlinearMinimizationResult"/> containing the results of the minimization.</returns>
+        NonlinearMinimizationResult FindMinimum(IObjectiveModel objective, double[] initialGuess,
+            double[] lowerBound = null, double[] upperBound = null, double[] scales = null, bool[] isFixed = null);
+    }
+}

--- a/src/Numerics/Optimization/LevenbergMarquardtMinimizer.cs
+++ b/src/Numerics/Optimization/LevenbergMarquardtMinimizer.cs
@@ -5,25 +5,39 @@ using System.Linq;
 
 namespace MathNet.Numerics.Optimization
 {
-    public class LevenbergMarquardtMinimizer : NonlinearMinimizerBase
+    /// <summary>
+    /// Implements the Levenberg-Marquardt algorithm for solving nonlinear least squares problems.
+    /// This class inherits from <see cref="NonlinearMinimizerBase"/> and implements <see cref="ILeastSquaresMinimizer"/>.
+    /// </summary>
+    public class LevenbergMarquardtMinimizer : NonlinearMinimizerBase, ILeastSquaresMinimizer
     {
         /// <summary>
         /// The scale factor for initial mu
         /// </summary>
         public double InitialMu { get; set; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LevenbergMarquardtMinimizer"/> class using the Levenberg-Marquardt algorithm.
+        /// </summary>
+        /// <param name="initialMu">The initial damping parameter (mu) for the algorithm. Default is 1E-3.</param>
+        /// <param name="gradientTolerance">The tolerance for the infinity norm of the gradient. Default is 1E-15.</param>
+        /// <param name="stepTolerance">The tolerance for the parameter update step size. Default is 1E-15.</param>
+        /// <param name="functionTolerance">The tolerance for the function value (residual sum of squares). Default is 1E-15.</param>
+        /// <param name="maximumIterations">The maximum number of iterations. Default is -1 (unlimited).</param>
         public LevenbergMarquardtMinimizer(double initialMu = 1E-3, double gradientTolerance = 1E-15, double stepTolerance = 1E-15, double functionTolerance = 1E-15, int maximumIterations = -1)
             : base(gradientTolerance, stepTolerance, functionTolerance, maximumIterations)
         {
             InitialMu = initialMu;
         }
 
+        /// <inheritdoc/>
         public NonlinearMinimizationResult FindMinimum(IObjectiveModel objective, Vector<double> initialGuess,
             Vector<double> lowerBound = null, Vector<double> upperBound = null, Vector<double> scales = null, List<bool> isFixed = null)
         {
             return Minimum(objective, initialGuess, lowerBound, upperBound, scales, isFixed, InitialMu, GradientTolerance, StepTolerance, FunctionTolerance, MaximumIterations);
         }
 
+        /// <inheritdoc/>
         public NonlinearMinimizationResult FindMinimum(IObjectiveModel objective, double[] initialGuess,
             double[] lowerBound = null, double[] upperBound = null, double[] scales = null, bool[] isFixed = null)
         {

--- a/src/Numerics/Optimization/TrustRegion/TrustRegionMinimizerBase.cs
+++ b/src/Numerics/Optimization/TrustRegion/TrustRegionMinimizerBase.cs
@@ -5,7 +5,11 @@ using MathNet.Numerics.LinearAlgebra;
 
 namespace MathNet.Numerics.Optimization.TrustRegion
 {
-    public abstract class TrustRegionMinimizerBase : NonlinearMinimizerBase
+    /// <summary>
+    /// Abstract base class for trust region minimizers that solve nonlinear least squares problems.
+    /// This class inherits from <see cref="NonlinearMinimizerBase"/> and implements <see cref="ILeastSquaresMinimizer"/>.
+    /// </summary>
+    public abstract class TrustRegionMinimizerBase : NonlinearMinimizerBase, ILeastSquaresMinimizer
     {
         /// <summary>
         /// The trust region subproblem.
@@ -17,6 +21,15 @@ namespace MathNet.Numerics.Optimization.TrustRegion
         /// </summary>
         public double RadiusTolerance { get; set; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TrustRegionMinimizerBase"/> class using the specified trust region subproblem.
+        /// </summary>
+        /// <param name="subproblem">The trust region subproblem to be solved at each iteration.</param>
+        /// <param name="gradientTolerance">The tolerance for the infinity norm of the gradient. Default is 1E-8.</param>
+        /// <param name="stepTolerance">The tolerance for the parameter update step size. Default is 1E-8.</param>
+        /// <param name="functionTolerance">The tolerance for the function value (residual sum of squares). Default is 1E-8.</param>
+        /// <param name="radiusTolerance">The tolerance for the trust region radius. Default is 1E-8.</param>
+        /// <param name="maximumIterations">The maximum number of iterations. Default is -1 (unlimited).</param>
         public TrustRegionMinimizerBase(ITrustRegionSubproblem subproblem,
             double gradientTolerance = 1E-8, double stepTolerance = 1E-8, double functionTolerance = 1E-8, double radiusTolerance = 1E-8, int maximumIterations = -1)
             : base(gradientTolerance, stepTolerance, functionTolerance, maximumIterations)
@@ -25,6 +38,7 @@ namespace MathNet.Numerics.Optimization.TrustRegion
             RadiusTolerance = radiusTolerance;
         }
 
+        /// <inheritdoc/>
         public NonlinearMinimizationResult FindMinimum(IObjectiveModel objective, Vector<double> initialGuess,
             Vector<double> lowerBound = null, Vector<double> upperBound = null, Vector<double> scales = null, List<bool> isFixed = null)
         {
@@ -32,6 +46,7 @@ namespace MathNet.Numerics.Optimization.TrustRegion
                 GradientTolerance, StepTolerance, FunctionTolerance, RadiusTolerance, MaximumIterations);
         }
 
+        /// <inheritdoc/>
         public NonlinearMinimizationResult FindMinimum(IObjectiveModel objective, double[] initialGuess,
             double[] lowerBound = null, double[] upperBound = null, double[] scales = null, bool[] isFixed = null)
         {


### PR DESCRIPTION
This PR introduces a unified interface for nonlinear least squares minimization algorithms.

### Changes
- Added new `ILeastSquaresMinimizer` interface 
- Defined two overloads of the `FindMinimum` method:
  - One accepting a `Vector<double>` parameter
  - One accepting a `double[]` parameter
- Updated `LevenbergMarquardtMinimizer` and `TrustRegionMinimizerBase` to implement this interface

## Purpose
This interface standardizes the API for least squares minimizers, preparing the codebase for future additions such as `BasinHopping` and other global nonlinear least squares minimizers.