### PR TITLE
Fix and Extend Trust Region Subproblem Implementations

### DIFF
--- a/src/Numerics.Tests/OptimizationTests/NonLinearCurveFittingTests.cs
+++ b/src/Numerics.Tests/OptimizationTests/NonLinearCurveFittingTests.cs
@@ -202,6 +202,20 @@ namespace MathNet.Numerics.Tests.OptimizationTests
         }
 
         [Test]
+        public void Rat43_TREXACT_Dif()
+        {
+            var obj = ObjectiveFunction.NonlinearModel(Rat43Model, Rat43X, Rat43Y, accuracyOrder: 6);
+            var solver = new TrustRegionExactMinimizer();
+            var result = solver.FindMinimum(obj, Rat43Start2);
+
+            for (var i = 0; i < result.MinimizingPoint.Count; i++)
+            {
+                AssertHelpers.AlmostEqualRelative(Rat43Pbest[i], result.MinimizingPoint[i], 2);
+                AssertHelpers.AlmostEqualRelative(Rat43Pstd[i], result.StandardErrors[i], 2);
+            }
+        }
+
+        [Test]
         public void Rat43_Bfgs_Dif()
         {
             var obj = ObjectiveFunction.NonlinearFunction(Rat43Model, Rat43X, Rat43Y, accuracyOrder: 6);
@@ -412,6 +426,20 @@ namespace MathNet.Numerics.Tests.OptimizationTests
         }
 
         [Test]
+        public void BoxBod_TREXACT_Dif()
+        {
+            var obj = ObjectiveFunction.NonlinearModel(BoxBodModel, BoxBodX, BoxBodY, accuracyOrder: 6);
+            var solver = new TrustRegionExactMinimizer();
+            var result = solver.FindMinimum(obj, BoxBodStart2);
+
+            for (var i = 0; i < result.MinimizingPoint.Count; i++)
+            {
+                AssertHelpers.AlmostEqualRelative(BoxBodPbest[i], result.MinimizingPoint[i], 3);
+                AssertHelpers.AlmostEqualRelative(BoxBodPstd[i], result.StandardErrors[i], 3);
+            }
+        }
+
+        [Test]
         public void BoxBod_Bfgs_Der()
         {
             var obj = ObjectiveFunction.NonlinearFunction(BoxBodModel, BoxBodPrime, BoxBodX, BoxBodY);
@@ -575,6 +603,20 @@ namespace MathNet.Numerics.Tests.OptimizationTests
             var result = solver.FindMinimum(obj, ThurberStart, scales: ThurberScales);
 
             for (int i = 0; i < result.MinimizingPoint.Count; i++)
+            {
+                AssertHelpers.AlmostEqualRelative(ThurberPbest[i], result.MinimizingPoint[i], 3);
+                AssertHelpers.AlmostEqualRelative(ThurberPstd[i], result.StandardErrors[i], 3);
+            }
+        }
+
+        [Test]
+        public void Thurber_TREXACT_Dif()
+        {
+            var obj = ObjectiveFunction.NonlinearModel(ThurberModel, ThurberX, ThurberY, accuracyOrder: 6);
+            var solver = new TrustRegionExactMinimizer();
+            var result = solver.FindMinimum(obj, ThurberStart, scales: ThurberScales);
+
+            for (var i = 0; i < result.MinimizingPoint.Count; i++)
             {
                 AssertHelpers.AlmostEqualRelative(ThurberPbest[i], result.MinimizingPoint[i], 3);
                 AssertHelpers.AlmostEqualRelative(ThurberPstd[i], result.StandardErrors[i], 3);

--- a/src/Numerics/Optimization/TrustRegion/ITrustRegionSubProblem.cs
+++ b/src/Numerics/Optimization/TrustRegion/ITrustRegionSubProblem.cs
@@ -2,11 +2,29 @@
 
 namespace MathNet.Numerics.Optimization.TrustRegion
 {
+    /// <summary>
+    /// Defines the interface for solving a trust region subproblem in nonlinear least squares minimization.
+    /// This interface provides properties to retrieve the computed step and a flag indicating whether the solution hit the trust region boundary,
+    /// as well as a method to solve the subproblem given an objective model and a trust region radius.
+    /// </summary>
     public interface ITrustRegionSubproblem
     {
+        /// <summary>
+        /// Gets the computed parameter step vector after solving the subproblem.
+        /// </summary>
         Vector<double> Pstep { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the solution of the subproblem hit the trust region boundary.
+        /// </summary>
         bool HitBoundary { get; }
 
-        void Solve(IObjectiveModel objective, double radius);
+        /// <summary>
+        /// Solves the trust region subproblem using the provided gradient and Hessian.
+        /// </summary>
+        /// <param name="gradient">The scaled gradient vector</param>
+        /// <param name="hessian">The scaled Hessian matrix</param>
+        /// <param name="delta">Trust region radius</param>
+        void Solve(Vector<double> gradient, Matrix<double> hessian, double delta);
     }
 }

--- a/src/Numerics/Optimization/TrustRegion/Subproblems/DogLegSubproblem.cs
+++ b/src/Numerics/Optimization/TrustRegion/Subproblems/DogLegSubproblem.cs
@@ -2,23 +2,32 @@
 
 namespace MathNet.Numerics.Optimization.TrustRegion.Subproblems
 {
+    /// <summary>
+    /// Implements the Dog-Leg method for solving trust region subproblems.
+    /// </summary>
+    /// <remarks>
+    /// The Dog-Leg method combines the Gauss-Newton step and the steepest descent step
+    /// to find an approximate solution to the trust region subproblem. It provides a good
+    /// compromise between the computational efficiency of steepest descent and the fast
+    /// convergence of Gauss-Newton near the solution.
+    /// </remarks>
     internal class DogLegSubproblem : ITrustRegionSubproblem
     {
+        /// <inheritdoc/>
         public Vector<double> Pstep { get; private set; }
 
+        /// <inheritdoc/>
         public bool HitBoundary { get; private set; }
 
-        public void Solve(IObjectiveModel objective, double delta)
+        /// <inheritdoc/>
+        public void Solve(Vector<double> gradient, Matrix<double> hessian, double delta)
         {
-            var Gradient = objective.Gradient;
-            var Hessian = objective.Hessian;
-
             // newton point, the Gauss–Newton step by solving the normal equations
-            var Pgn = -Hessian.PseudoInverse() * Gradient; // Hessian.Solve(Gradient) fails so many times...
+            var Pgn = -hessian.PseudoInverse() * gradient; // hessian.Solve(gradient) fails so many times...
 
             // cauchy point, steepest descent direction is given by
-            var alpha = Gradient.DotProduct(Gradient) / (Hessian * Gradient).DotProduct(Gradient);
-            var Psd = -alpha * Gradient;
+            var alpha = gradient.DotProduct(gradient) / (hessian * gradient).DotProduct(gradient);
+            var Psd = -alpha * gradient;
 
             // update step and prectted reduction
             if (Pgn.L2Norm() <= delta)

--- a/src/Numerics/Optimization/TrustRegion/Subproblems/ExactSubproblem.cs
+++ b/src/Numerics/Optimization/TrustRegion/Subproblems/ExactSubproblem.cs
@@ -1,0 +1,235 @@
+﻿// <copyright file="ExactSubproblem.cs" company="Math.NET">
+// Math.NET Numerics, part of the Math.NET Project
+// https://numerics.mathdotnet.com
+// https://github.com/mathnet/mathnet-numerics
+//
+// Copyright (c) 2009-$CURRENT_YEAR$ Math.NET
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+
+using MathNet.Numerics.LinearAlgebra;
+using System;
+using System.Linq;
+
+namespace MathNet.Numerics.Optimization.TrustRegion.Subproblems
+{
+    /// <summary>
+    /// Implements the Exact method for solving trust region subproblems.
+    /// </summary>
+    /// <remarks>
+    /// The Exact method uses eigenvalue decomposition to find the exact solution to the trust region subproblem.
+    /// It is more computationally expensive than other methods but can provide more accurate solutions,
+    /// especially when the Hessian is indefinite or when high accuracy is required.
+    /// </remarks>
+    internal class ExactSubproblem : ITrustRegionSubproblem
+    {
+        /// <inheritdoc/>
+        public Vector<double> Pstep { get; private set; }
+
+        /// <inheritdoc/>
+        public bool HitBoundary { get; private set; }
+
+        /// <inheritdoc/>
+        public void Solve(Vector<double> gradient, Matrix<double> hessian, double delta)
+        {
+            // Get the dimension of the problem
+            var n = gradient.Count;
+
+            try
+            {
+                // Perform eigenvalue decomposition of the Hessian
+                var evd = hessian.Evd();
+                var Q = evd.EigenVectors;
+                var eigvals = evd.EigenValues.Real();
+
+                // Transform the gradient to the eigenvector basis
+                var gHat = Q.Transpose() * gradient;
+
+                // Try the interior solution first
+                var isInteriorValid = true;
+                var pInterior = Vector<double>.Build.Dense(n);
+
+                // Tolerance for numerical stability
+                const double epsilon = 1e-12;
+
+                for (var i = 0; i < n; i++)
+                {
+                    if (Math.Abs(eigvals[i]) < epsilon)
+                    {
+                        // Handle zero eigenvalues
+                        if (Math.Abs(gHat[i]) > epsilon)
+                        {
+                            // If gHat[i] != 0 when λ_i = 0, Newton step goes to infinity
+                            isInteriorValid = false;
+                            break;
+                        }
+                        pInterior[i] = 0;
+                    }
+                    else if (eigvals[i] < 0)
+                    {
+                        // Negative eigenvalue implies the Hessian is not positive definite
+                        isInteriorValid = false;
+                        break;
+                    }
+                    else
+                    {
+                        // Compute the Newton step component
+                        pInterior[i] = -gHat[i] / eigvals[i];
+                    }
+                }
+
+                if (isInteriorValid)
+                {
+                    // Transform back to original coordinates
+                    var p = Q * pInterior;
+
+                    // Check if the solution is within the trust region
+                    if (p.L2Norm() <= delta)
+                    {
+                        Pstep = p;
+                        HitBoundary = false;
+                        return;
+                    }
+                }
+
+                // If the Newton step is outside the trust region or invalid,
+                // solve the constrained problem with the solution on the boundary
+
+                // Find the optimal Lagrange multiplier lambda using a root-finding approach
+                var lambda = FindOptimalLambda(eigvals, gHat, delta);
+
+                // Compute the solution with this lambda
+                var pBoundary = Vector<double>.Build.Dense(n);
+                for (var i = 0; i < n; i++)
+                {
+                    var denominator = eigvals[i] + lambda;
+                    if (Math.Abs(denominator) < epsilon)
+                    {
+                        // Handle potential division by near-zero
+                        pBoundary[i] = gHat[i] > 0 ? -delta : delta;
+                    }
+                    else
+                    {
+                        pBoundary[i] = -gHat[i] / denominator;
+                    }
+                }
+
+                // Transform back to original coordinates
+                Pstep = Q * pBoundary;
+                HitBoundary = true;
+            }
+            catch (Exception)
+            {
+                // Fallback to a more robust method if eigenvalue decomposition fails
+                // For example, use a steepest descent step
+                var alpha = gradient.DotProduct(gradient) / (hessian * gradient).DotProduct(gradient);
+                Pstep = -Math.Min(alpha, delta / gradient.L2Norm()) * gradient;
+                HitBoundary = alpha * gradient.L2Norm() >= delta;
+            }
+        }
+
+        /// <summary>
+        /// Finds the optimal Lagrange multiplier to ensure the solution lies on the trust region boundary.
+        /// </summary>
+        /// <param name="eigvals">Eigenvalues of the Hessian</param>
+        /// <param name="gHat">Gradient in the eigenvector basis</param>
+        /// <param name="delta">Trust region radius</param>
+        /// <returns>The optimal Lagrange multiplier</returns>
+        private static double FindOptimalLambda(Vector<double> eigvals, Vector<double> gHat, double delta)
+        {
+            // Tolerance for numerical stability
+            const double epsilon = 1e-12;
+            const int maxIterations = 100;
+            const double tolerance = 1e-10;
+
+            // Function to evaluate the norm of the solution for a given lambda
+            double PhiFunction(double lambda)
+            {
+                var sum = 0.0;
+                for (var i = 0; i < eigvals.Count; i++)
+                {
+                    var denominator = eigvals[i] + lambda;
+                    if (Math.Abs(denominator) > epsilon)
+                    {
+                        var term = gHat[i] / denominator;
+                        sum += term * term;
+                    }
+                    else if (Math.Abs(gHat[i]) > epsilon)
+                    {
+                        // If denominator is near zero but gHat[i] is not, 
+                        // this would result in a very large term
+                        return double.PositiveInfinity;
+                    }
+                }
+                return Math.Sqrt(sum) - delta;
+            }
+
+            // Find the minimum eigenvalue to establish a lower bound for lambda
+            var lambdaMin = -eigvals.Min();
+
+            // Start with lambdaMin plus a small value to ensure positive definiteness
+            var lambdaLower = Math.Max(0.0, lambdaMin + epsilon);
+            var lambdaUpper = lambdaLower + 1.0;
+
+            // Expand the upper bound until phi(lambdaUpper) < 0
+            var expandCount = 0;
+            while (PhiFunction(lambdaUpper) > 0 && expandCount < 30)
+            {
+                lambdaLower = lambdaUpper;
+                lambdaUpper *= 10;
+                expandCount++;
+            }
+
+            if (expandCount >= 30)
+            {
+                // If we can't find a suitable upper bound, use a fallback value
+                return lambdaUpper;
+            }
+
+            // Use bisection method to find the root of the phi function
+            var lambdaMid = 0.0;
+            double phiMid;
+            for (var i = 0; i < maxIterations; i++)
+            {
+                lambdaMid = (lambdaLower + lambdaUpper) / 2.0;
+                phiMid = PhiFunction(lambdaMid);
+
+                if (Math.Abs(phiMid) < tolerance)
+                {
+                    break;
+                }
+
+                if (phiMid > 0)
+                {
+                    lambdaLower = lambdaMid;
+                }
+                else
+                {
+                    lambdaUpper = lambdaMid;
+                }
+            }
+
+            return lambdaMid;
+        }
+    }
+}

--- a/src/Numerics/Optimization/TrustRegion/Subproblems/NewtonCGSubproblem.cs
+++ b/src/Numerics/Optimization/TrustRegion/Subproblems/NewtonCGSubproblem.cs
@@ -3,35 +3,54 @@ using MathNet.Numerics.LinearAlgebra;
 
 namespace MathNet.Numerics.Optimization.TrustRegion.Subproblems
 {
+    /// <summary>
+    /// Implements the Newton Conjugate Gradient method for solving trust region subproblems.
+    /// </summary>
+    /// <remarks>
+    /// The Newton-CG method iteratively improves the solution using conjugate gradient iterations
+    /// while ensuring the solution stays within the trust region boundary. This method is
+    /// particularly effective for large-scale problems and can handle cases where the Hessian
+    /// is indefinite by detecting directions of negative curvature.
+    /// </remarks>
     internal class NewtonCGSubproblem : ITrustRegionSubproblem
     {
+        /// <inheritdoc/>
         public Vector<double> Pstep { get; private set; }
 
+        /// <inheritdoc/>
         public bool HitBoundary { get; private set; }
 
-        public void Solve(IObjectiveModel objective, double delta)
+        /// <inheritdoc/>
+        public void Solve(Vector<double> gradient, Matrix<double> hessian, double delta)
         {
-            var Gradient = objective.Gradient;
-            var Hessian = objective.Hessian;
-
             // define tolerance
-            var gnorm = Gradient.L2Norm();
+            var gnorm = gradient.L2Norm();
             var tolerance = Math.Min(0.5, Math.Sqrt(gnorm)) * gnorm;
 
             // initialize internal variables
-            var z = Vector<double>.Build.Dense(Hessian.RowCount);
-            var r = Gradient;
+            var z = Vector<double>.Build.Dense(hessian.RowCount);
+            var r = gradient;
             var d = -r;
 
             while (true)
             {
-                var Bd = Hessian * d;
+                var Bd = hessian * d;
                 var dBd = d.DotProduct(Bd);
 
                 if (dBd <= 0)
                 {
+                    // Direction of negative curvature found
+                    // Calculate two boundary points and choose the one with lower model value
                     var t = Util.FindBeta(1, z, d, delta);
-                    Pstep = z + t.Item1 * d;
+                    var pa = z + t.Item1 * d;
+                    var pb = z + t.Item2 * d;
+
+                    // Evaluate quadratic model at both points
+                    var valueA = Util.CalculateQuadraticModel(gradient, hessian, pa);
+                    var valueB = Util.CalculateQuadraticModel(gradient, hessian, pb);
+
+                    // Choose the point with the lower model value
+                    Pstep = valueA < valueB ? pa : pb;
                     HitBoundary = true;
                     return;
                 }
@@ -39,7 +58,7 @@ namespace MathNet.Numerics.Optimization.TrustRegion.Subproblems
                 var r_sq = r.DotProduct(r);
                 var alpha = r_sq / dBd;
                 var znext = z + alpha * d;
-                if(znext.L2Norm() >= delta)
+                if (znext.L2Norm() >= delta)
                 {
                     var t = Util.FindBeta(1, z, d, delta);
                     Pstep = z + t.Item2 * d;

--- a/src/Numerics/Optimization/TrustRegion/Subproblems/Util.cs
+++ b/src/Numerics/Optimization/TrustRegion/Subproblems/Util.cs
@@ -5,6 +5,14 @@ namespace MathNet.Numerics.Optimization.TrustRegion.Subproblems
 {
     internal static class Util
     {
+        /// <summary>
+        /// Finds the two intersection points of a line with the trust region boundary.
+        /// </summary>
+        /// <param name="alpha">Scaling factor for steepest descent direction</param>
+        /// <param name="sd">Steepest descent direction vector</param>
+        /// <param name="gn">Gauss-Newton direction vector</param>
+        /// <param name="delta">Trust region radius</param>
+        /// <returns>A tuple containing two beta values, sorted from low to high</returns>
         public static (double, double) FindBeta(double alpha, Vector<double> sd, Vector<double> gn, double delta)
         {
             // Pstep is intersection of the trust region boundary
@@ -28,6 +36,25 @@ namespace MathNet.Numerics.Optimization.TrustRegion.Subproblems
 
             // return sorted beta
             return beta1 < beta2 ? (beta1, beta2) : (beta2, beta1);
+        }
+
+        /// <summary>
+        /// Calculates the value of the quadratic model at a given point.
+        /// The quadratic model is defined as:
+        ///     m(p) = g^T * p + 0.5 * p^T * H * p
+        /// where g is the gradient and H is the Hessian at the current point.
+        /// </summary>
+        /// <param name="gradient">The gradient vector</param>
+        /// <param name="hessian">The Hessian matrix</param>
+        /// <param name="p">The point at which to evaluate the quadratic model</param>
+        /// <returns>The value of the quadratic model at point p</returns>
+        public static double CalculateQuadraticModel(Vector<double> gradient, Matrix<double> hessian, Vector<double> p)
+        {
+            // Quadratic model: m(p) = g^T * p + 0.5 * p^T * H * p
+            var linearTerm = gradient.DotProduct(p);
+            var quadraticTerm = 0.5 * p.DotProduct(hessian * p);
+
+            return linearTerm + quadraticTerm;
         }
     }
 }

--- a/src/Numerics/Optimization/TrustRegion/TrustRegionDogLegMinimizer.cs
+++ b/src/Numerics/Optimization/TrustRegion/TrustRegionDogLegMinimizer.cs
@@ -1,10 +1,19 @@
 ﻿namespace MathNet.Numerics.Optimization.TrustRegion
 {
+    /// <summary>
+    /// Implements nonlinear least squares fitting using the trust region dogleg algorithm.
+    /// This class inherits from <see cref="TrustRegionMinimizerBase"/>.
+    /// </summary>
     public sealed class TrustRegionDogLegMinimizer : TrustRegionMinimizerBase
     {
         /// <summary>
-        /// Non-linear least square fitting by the trust region dogleg algorithm.
+        /// Initializes a new instance of the <see cref="TrustRegionDogLegMinimizer"/> class using the trust region dogleg algorithm.
         /// </summary>
+        /// <param name="gradientTolerance">The tolerance for the infinity norm of the gradient. Default is 1E-8.</param>
+        /// <param name="stepTolerance">The tolerance for the parameter update step size. Default is 1E-8.</param>
+        /// <param name="functionTolerance">The tolerance for the function value (residual sum of squares). Default is 1E-8.</param>
+        /// <param name="radiusTolerance">The tolerance for the trust region radius. Default is 1E-8.</param>
+        /// <param name="maximumIterations">The maximum number of iterations. Default is -1 (unlimited).</param>
         public TrustRegionDogLegMinimizer(double gradientTolerance = 1E-8, double stepTolerance = 1E-8, double functionTolerance = 1E-8, double radiusTolerance = 1E-8, int maximumIterations = -1)
             : base(TrustRegionSubproblem.DogLeg(), gradientTolerance, stepTolerance, functionTolerance, radiusTolerance, maximumIterations)
         { }

--- a/src/Numerics/Optimization/TrustRegion/TrustRegionExactMinimizer.cs
+++ b/src/Numerics/Optimization/TrustRegion/TrustRegionExactMinimizer.cs
@@ -1,0 +1,54 @@
+﻿// <copyright file="TrustRegionExactMinimizer.cs" company="Math.NET">
+// Math.NET Numerics, part of the Math.NET Project
+// https://numerics.mathdotnet.com
+// https://github.com/mathnet/mathnet-numerics
+//
+// Copyright (c) 2009-$CURRENT_YEAR$ Math.NET
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+
+namespace MathNet.Numerics.Optimization.TrustRegion
+{
+    /// <summary>
+    /// Implements a trust region minimizer using the Exact subproblem solver with eigenvalue decomposition.
+    /// </summary>
+    /// <remarks>
+    /// The Exact method provides the most accurate solution to the trust region subproblem but is more
+    /// computationally expensive. It's particularly useful when high accuracy is required or when
+    /// the Hessian has negative eigenvalues.
+    /// </remarks>
+    public sealed class TrustRegionExactMinimizer : TrustRegionMinimizerBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TrustRegionExactMinimizer"/> class.
+        /// </summary>
+        /// <param name="gradientTolerance">The gradient tolerance used to determine convergence.</param>
+        /// <param name="stepTolerance">The step size tolerance used to determine convergence.</param>
+        /// <param name="functionTolerance">The function value tolerance used to determine convergence.</param>
+        /// <param name="radiusTolerance">The trust region radius tolerance used to determine convergence.</param>
+        /// <param name="maximumIterations">The maximum number of iterations. -1 means no limit.</param>
+        public TrustRegionExactMinimizer(double gradientTolerance = 1E-8, double stepTolerance = 1E-8, double functionTolerance = 1E-8, double radiusTolerance = 1E-8, int maximumIterations = -1)
+            : base(TrustRegionSubproblem.Exact(), gradientTolerance, stepTolerance, functionTolerance, radiusTolerance, maximumIterations)
+        { }
+    }
+}

--- a/src/Numerics/Optimization/TrustRegion/TrustRegionMinimizerBase.cs
+++ b/src/Numerics/Optimization/TrustRegion/TrustRegionMinimizerBase.cs
@@ -161,7 +161,7 @@ namespace MathNet.Numerics.Optimization.TrustRegion
                 iterations++;
 
                 // solve the subproblem
-                subproblem.Solve(objective, delta);
+                subproblem.Solve(Gradient, Hessian, delta);
                 Pstep = subproblem.Pstep;
                 hitBoundary = subproblem.HitBoundary;
 

--- a/src/Numerics/Optimization/TrustRegion/TrustRegionNewtonCGMinimizer.cs
+++ b/src/Numerics/Optimization/TrustRegion/TrustRegionNewtonCGMinimizer.cs
@@ -1,10 +1,19 @@
 ﻿namespace MathNet.Numerics.Optimization.TrustRegion
 {
+    /// <summary>
+    /// Implements nonlinear least squares fitting using the trust region Newton-Conjugate-Gradient algorithm.
+    /// This class inherits from <see cref="TrustRegionMinimizerBase"/>.
+    /// </summary>
     public sealed class TrustRegionNewtonCGMinimizer : TrustRegionMinimizerBase
     {
         /// <summary>
-        /// Non-linear least square fitting by the trust region Newton-Conjugate-Gradient algorithm.
+        /// Initializes a new instance of the <see cref="TrustRegionNewtonCGMinimizer"/> class using the trust region Newton-Conjugate-Gradient algorithm.
         /// </summary>
+        /// <param name="gradientTolerance">The tolerance for the infinity norm of the gradient. Default is 1E-8.</param>
+        /// <param name="stepTolerance">The tolerance for the parameter update step size. Default is 1E-8.</param>
+        /// <param name="functionTolerance">The tolerance for the function value (residual sum of squares). Default is 1E-8.</param>
+        /// <param name="radiusTolerance">The tolerance for the trust region radius. Default is 1E-8.</param>
+        /// <param name="maximumIterations">The maximum number of iterations. Default is -1 (unlimited).</param>
         public TrustRegionNewtonCGMinimizer(double gradientTolerance = 1E-8, double stepTolerance = 1E-8, double functionTolerance = 1E-8, double radiusTolerance = 1E-8, int maximumIterations = -1)
             : base(TrustRegionSubproblem.NewtonCG(), gradientTolerance, stepTolerance, functionTolerance, radiusTolerance, maximumIterations)
         { }

--- a/src/Numerics/Optimization/TrustRegion/TrustRegionSubProblem.cs
+++ b/src/Numerics/Optimization/TrustRegion/TrustRegionSubProblem.cs
@@ -24,5 +24,14 @@ namespace MathNet.Numerics.Optimization.TrustRegion
         {
             return new NewtonCGSubproblem();
         }
+
+        /// <summary>
+        /// Creates an instance of the trust region subproblem using the Exact algorithm with eigenvalue decomposition.
+        /// </summary>
+        /// <returns>An implementation of <see cref="ITrustRegionSubproblem"/> based on the Exact method.</returns>
+        public static ITrustRegionSubproblem Exact()
+        {
+            return new ExactSubproblem();
+        }
     }
 }

--- a/src/Numerics/Optimization/TrustRegion/TrustRegionSubProblem.cs
+++ b/src/Numerics/Optimization/TrustRegion/TrustRegionSubProblem.cs
@@ -2,13 +2,24 @@
 
 namespace MathNet.Numerics.Optimization.TrustRegion
 {
+    /// <summary>
+    /// Provides factory methods for creating instances of trust region subproblems.
+    /// </summary>
     public static class TrustRegionSubproblem
     {
+        /// <summary>
+        /// Creates an instance of the trust region subproblem using the dogleg algorithm.
+        /// </summary>
+        /// <returns>An implementation of <see cref="ITrustRegionSubproblem"/> based on the dogleg method.</returns>
         public static ITrustRegionSubproblem DogLeg()
         {
             return new DogLegSubproblem();
         }
 
+        /// <summary>
+        /// Creates an instance of the trust region subproblem using the Newton-Conjugate-Gradient algorithm.
+        /// </summary>
+        /// <returns>An implementation of <see cref="ITrustRegionSubproblem"/> based on the Newton-CG method.</returns>
         public static ITrustRegionSubproblem NewtonCG()
         {
             return new NewtonCGSubproblem();


### PR DESCRIPTION
This PR fixes critical issues in the Trust Region optimization implementation.

### Bugs Fixed
1. **Scaling Issue**: Subproblem solvers were using unscaled gradient and Hessian values directly from the `IObjectiveModel`, while they should have been using the scaled values that `NonlinearMinimizerBase.EvaluateJacobian` produces.

2. **NewtonCG Algorithm Improvement**: Enhanced the handling of negative curvature directions in the NewtonCG subproblem solver.