### PR TITLE
Fixes a typo in the implementation of `BesselK1e`

### DIFF
--- a/src/Numerics.Tests/SpecialFunctionsTests/ModifiedBesselTests.cs
+++ b/src/Numerics.Tests/SpecialFunctionsTests/ModifiedBesselTests.cs
@@ -114,6 +114,7 @@ namespace MathNet.Numerics.Tests.SpecialFunctionsTests
         public void BesselK1Exact(double x, double expected)
         {
             AssertHelpers.AlmostEqualRelative(expected, SpecialFunctions.BesselK1(x), 14);
+            AssertHelpers.AlmostEqualRelative(expected * Math.Exp(x), SpecialFunctions.BesselK1e(x), 14);
         }
     }
 }

--- a/src/Numerics/SpecialFunctions/ModifiedBessel.cs
+++ b/src/Numerics/SpecialFunctions/ModifiedBessel.cs
@@ -282,7 +282,7 @@ namespace MathNet.Numerics
             if (x <= 2.0)
             {
                 double y = x * x - 2.0;
-                return Math.Log(0.5 * x) * BesselI1(x) + Evaluate.ChebyshevA(BesselK1A, y) / x * Math.Exp(x);
+                return (Math.Log(0.5 * x) * BesselI1(x) + Evaluate.ChebyshevA(BesselK1A, y) / x) * Math.Exp(x);
             }
 
             double x1 = 8.0 / x - 2.0;


### PR DESCRIPTION
Closes #1142. Added tests to verify the correct behavior of BesselK1e. 